### PR TITLE
add version command to schemahero binary and version info to manager logs

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -18,16 +18,19 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 
-	"github.com/schemahero/schemahero/pkg/apis"
-	"github.com/schemahero/schemahero/pkg/controller"
-	"github.com/schemahero/schemahero/pkg/webhook"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
+
+	"github.com/schemahero/schemahero/pkg/apis"
+	"github.com/schemahero/schemahero/pkg/controller"
+	"github.com/schemahero/schemahero/pkg/version"
+	"github.com/schemahero/schemahero/pkg/webhook"
 )
 
 func main() {
@@ -36,6 +39,8 @@ func main() {
 	flag.Parse()
 	logf.SetLogger(logf.ZapLogger(false))
 	log := logf.Log.WithName("entrypoint")
+
+	log.Info(fmt.Sprintf("%+v", version.GetBuild()))
 
 	// Get a config to talk to the apiserver
 	log.Info("setting up client for manager")

--- a/deploy/.goreleaser.integration.yml
+++ b/deploy/.goreleaser.integration.yml
@@ -26,6 +26,11 @@ builds:
     env:
       - CGO_ENABLED=0
     main: cmd/manager/main.go
+    ldflags: -s -w
+      -X github.com/schemahero/schemahero/pkg/version.version={{.Version}}
+      -X github.com/schemahero/schemahero/pkg/version.gitSHA={{.Commit}}
+      -X github.com/schemahero/schemahero/pkg/version.buildTime={{.Date}}
+      -extldflags "-static"
     flags: -tags netgo -installsuffix netgo
     binary: manager
     hooks: {}

--- a/deploy/.goreleaser.snapshot.yml
+++ b/deploy/.goreleaser.snapshot.yml
@@ -29,6 +29,11 @@ builds:
     env:
       - CGO_ENABLED=0
     main: cmd/manager/main.go
+    ldflags: -s -w
+      -X github.com/schemahero/schemahero/pkg/version.version={{.Version}}
+      -X github.com/schemahero/schemahero/pkg/version.gitSHA={{.Commit}}
+      -X github.com/schemahero/schemahero/pkg/version.buildTime={{.Date}}
+      -extldflags "-static"
     flags: -tags netgo -installsuffix netgo
     binary: manager
     hooks: {}

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -25,6 +25,7 @@ func RootCmd() *cobra.Command {
 	cmd.AddCommand(Watch())
 	cmd.AddCommand(Generate())
 	cmd.AddCommand(Fixtures())
+	cmd.AddCommand(Version())
 
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	return cmd

--- a/pkg/cli/version.go
+++ b/pkg/cli/version.go
@@ -1,0 +1,23 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/schemahero/schemahero/pkg/version"
+)
+
+func Version() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "schemahero version information",
+		Long:  `...`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fmt.Printf("%+v\n", version.GetBuild())
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/pkg/version/build.go
+++ b/pkg/version/build.go
@@ -1,0 +1,7 @@
+package version
+
+// NOTE: these variables are injected at build time
+
+var (
+	version, gitSHA, buildTime string
+)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,64 @@
+package version
+
+import (
+	"time"
+)
+
+var (
+	build    Build
+	hasBuilt = false
+)
+
+// Build holds details about this build of the Ship binary
+type Build struct {
+	Version      string    `json:"version,omitempty"`
+	GitSHA       string    `json:"git,omitempty"`
+	BuildTime    time.Time `json:"buildTime,omitempty"`
+	TimeFallback string    `json:"buildTimeFallback,omitempty"`
+}
+
+// Init sets up the version info from build args
+func Init() {
+	build.Version = version
+	if len(gitSHA) >= 7 {
+		build.GitSHA = gitSHA[:7]
+	}
+	var err error
+	build.BuildTime, err = time.Parse(time.RFC3339, buildTime)
+	if err != nil {
+		build.TimeFallback = buildTime
+	}
+	hasBuilt = true
+}
+
+// GetBuild gets the build
+func GetBuild() Build {
+	if !hasBuilt {
+		Init()
+	}
+	return build
+}
+
+// Version gets the version
+func Version() string {
+	if !hasBuilt {
+		Init()
+	}
+	return build.Version
+}
+
+// GitSHA gets the gitsha
+func GitSHA() string {
+	if !hasBuilt {
+		Init()
+	}
+	return build.GitSHA
+}
+
+// BuildTime gets the build time
+func BuildTime() time.Time {
+	if !hasBuilt {
+		Init()
+	}
+	return build.BuildTime
+}


### PR DESCRIPTION
Until we push our first tag the version info will be "" but it'll still contain build time and commit sha