### PR TITLE
Index comparison

### DIFF
--- a/pkg/database/mysql/index.go
+++ b/pkg/database/mysql/index.go
@@ -23,11 +23,7 @@ func AddIndexStatement(tableName string, schemaIndex *schemasv1alpha2.SQLTableIn
 		name = types.GenerateIndexName(tableName, schemaIndex)
 	}
 
-	return fmt.Sprintf("create %sindex %s on %s (%s)",
-		unique,
-		name,
-		tableName,
-		strings.Join(schemaIndex.Columns, ", "))
+	return fmt.Sprintf("create %sindex %s on %s (%s)", unique, name, tableName, strings.Join(schemaIndex.Columns, ", "))
 }
 
 func RenameIndexStatement(tableName string, index *types.Index, schemaIndex *schemasv1alpha2.SQLTableIndex) string {

--- a/pkg/database/postgres/deploy.go
+++ b/pkg/database/postgres/deploy.go
@@ -38,17 +38,6 @@ func DeployPostgresTable(uri string, tableName string, postgresTableSchema *sche
 			return err
 		}
 
-		if postgresTableSchema.Indexes != nil {
-			for _, index := range postgresTableSchema.Indexes {
-				createIndex := AddIndexStatement(tableName, index)
-
-				fmt.Printf("Executing query: %q\n", createIndex)
-				_, err := p.db.Exec(query)
-				if err != nil {
-					return err
-				}
-			}
-		}
 		return nil
 	}
 
@@ -271,6 +260,10 @@ func buildIndexStatements(p *PostgresConnection, tableName string, postgresTable
 	}
 
 	for _, index := range postgresTableSchema.Indexes {
+		if index.Name == "" {
+			index.Name = types.GenerateIndexName(tableName, index)
+		}
+
 		var statement string
 		var matchedIndex *types.Index
 		for _, currentIndex := range currentIndexes {

--- a/pkg/database/postgres/index.go
+++ b/pkg/database/postgres/index.go
@@ -10,9 +10,7 @@ import (
 )
 
 func RemoveIndexStatement(tableName string, index *types.Index) string {
-	return fmt.Sprintf(
-		"drop index %s",
-		pq.QuoteIdentifier(index.Name))
+	return fmt.Sprintf("drop index %s", pq.QuoteIdentifier(index.Name))
 }
 
 func AddIndexStatement(tableName string, schemaIndex *schemasv1alpha2.SQLTableIndex) string {
@@ -34,8 +32,5 @@ func AddIndexStatement(tableName string, schemaIndex *schemasv1alpha2.SQLTableIn
 }
 
 func RenameIndexStatement(tableName string, index *types.Index, schemaIndex *schemasv1alpha2.SQLTableIndex) string {
-	return fmt.Sprintf(
-		"alter index %s rename to %s",
-		pq.QuoteIdentifier(index.Name),
-		pq.QuoteIdentifier(schemaIndex.Name))
+	return fmt.Sprintf("alter index %s rename to %s", pq.QuoteIdentifier(index.Name), pq.QuoteIdentifier(schemaIndex.Name))
 }

--- a/pkg/database/types/index.go
+++ b/pkg/database/types/index.go
@@ -14,9 +14,30 @@ type Index struct {
 }
 
 func (idx *Index) Equals(other *Index) bool {
-	// TODO
+	if idx.Name != other.Name {
+		return false
+	}
 
-	return false
+	if idx.IsUnique != other.IsUnique {
+		return false
+	}
+
+	if len(idx.Columns) != len(other.Columns) {
+		return false
+	}
+
+	for _, otherColumn := range other.Columns {
+		for _, col := range idx.Columns {
+			if col == otherColumn {
+				goto NextColumn
+			}
+		}
+
+		return false
+
+	NextColumn:
+	}
+	return true
 }
 
 func IndexToSchemaIndex(index *Index) *schemasv1alpha2.SQLTableIndex {


### PR DESCRIPTION
This will prevent dropping indexes on fixture generation if it already exists.