### PR TITLE
Add initial support for postgres arrays

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -276,9 +276,8 @@ golang.org/x/tools v0.0.0-20181011042414-1f849cf54d09/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
-golang.org/x/tools v0.0.0-20190729092621-ff9f1409240a h1:mEQZbbaBjWyLNy0tmZmgEuQAR8XOQ3hL8GYi3J/NG64=
 golang.org/x/tools v0.0.0-20190729092621-ff9f1409240a/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=
-gomodules.xyz/jsonpatch/v2 v2.0.0 h1:lHNQverf0+Gm1TbSbVIDWVXOhZ2FpZopxRqpr2uIjs4=
+gomodules.xyz/jsonpatch/v2 v2.0.0 h1:OyHbl+7IOECpPKfVK42oFr6N7+Y2dR+Jsb/IiDV3hOo=
 gomodules.xyz/jsonpatch/v2 v2.0.0/go.mod h1:IhYNNY4jnS53ZnfE4PAmpKtDpTCj1JFXc+3mwe7XcUU=
 google.golang.org/appengine v1.1.0 h1:igQkv0AAhEIvTEpD5LIpAfav2eeVO9HBTjvKHVJPRSs=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=

--- a/pkg/database/postgres/column.go
+++ b/pkg/database/postgres/column.go
@@ -22,8 +22,10 @@ func schemaColumnToColumn(schemaColumn *schemasv1alpha2.SQLTableColumn) (*types.
 	}
 
 	requestedType := schemaColumn.Type
-	requestedType = strings.Split(requestedType, "[")[0]
 
+	// split on the "[" character, which is only present in arrays
+	requestedType = strings.Split(requestedType, "[")[0]
+	// if the first element after splitting is not the entire string, it's an array
 	column.IsArray = len(requestedType) < len(schemaColumn.Type)
 
 	unaliasedColumnType := unaliasUnparameterizedColumnType(requestedType)

--- a/pkg/database/postgres/column_test.go
+++ b/pkg/database/postgres/column_test.go
@@ -69,6 +69,14 @@ func Test_postgresColumnAsInsert(t *testing.T) {
 			},
 			expectedStatement: `"c" integer default '11'`,
 		},
+		{
+			name: "text[]",
+			column: &schemasv1alpha2.SQLTableColumn{
+				Name: "c",
+				Type: "text[]",
+			},
+			expectedStatement: `"c" text[]`,
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/database/types/column.go
+++ b/pkg/database/types/column.go
@@ -20,6 +20,7 @@ type Column struct {
 	DataType      string
 	ColumnDefault *string
 	Constraints   *ColumnConstraints
+	IsArray       bool
 }
 
 func ColumnToSchemaColumn(column *Column) (*schemasv1alpha2.SQLTableColumn, error) {


### PR DESCRIPTION
This (partially) addresses #80 

With this addition, single-dimension, unsized arrays are supported. This does not attempt to add support for multi-dimension or sized arrays.