### PR TITLE
Kots

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -1,8 +1,8 @@
 name: "Build and test"
 on:
   push:
-    branches-ignore: [master] # master branch runs alpha-release workflow
     tags-ignore: ["*"] # tags run tagged-release workflow
+    branches: ["*"]
 
 jobs:
   build:
@@ -81,3 +81,35 @@ jobs:
       - run: make -C integration/tests/mysql/index-create run
       - run: make -C integration/tests/mysql/primary-key-add run
       - run: make -C integration/tests/mysql/primary-key-drop run
+
+  kots:
+    runs-on: ubuntu-latest
+    name: kots
+    needs: [test-mysql, test-postgres]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Download kubectl-schemahero binary
+        uses: actions/download-artifact@v1
+        with:
+          name: kubectl-schemahero
+          path: bin/
+      - run: chmod +x bin/kubectl-schemahero
+
+      - run: ./bin/kubectl-schemahero install --yaml --out-dir ./kots
+
+      - name: Lint the release
+        id: lint-action
+        uses: replicatedhq/action-kots-lint@v0.1.0
+        with:
+          replicated-app: "schemahero-enterprise"
+          replicated-api-token: ${{ secrets.REPLICATED_API_TOKEN }}
+          yaml-dir: kots
+      - name: Create the release
+        id: test-action
+        uses: replicatedhq/action-kots-release@v0.2.0
+        with:
+          replicated-app: "schemahero-enterprise"
+          replicated-api-token: ${{ secrets.REPLICATED_API_TOKEN }}
+          yaml-dir: kots

--- a/kots/application.yaml
+++ b/kots/application.yaml
@@ -1,0 +1,9 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: schemahero-enterprise
+  labels:
+    app.kubernetes.io/name: schemahero-enterprise
+spec:
+  descriptor:
+    links: []

--- a/kots/config.yaml
+++ b/kots/config.yaml
@@ -1,0 +1,18 @@
+apiVersion: kots.io/v1beta1
+kind: Config
+metadata:
+  name: config-sample
+spec:
+  groups:
+    - name: example_settings
+      title: My Example Config
+      description: Configuration to serve as an example for creating your own
+      items:
+        - name: a_bool
+          title: a bool field
+          help_text: When enabled we will not change anything, because this is an example
+          type: bool
+          default: "0"
+        - name: a_text
+          title: a text field
+          type: text

--- a/kots/preflight.yaml
+++ b/kots/preflight.yaml
@@ -1,0 +1,18 @@
+apiVersion: troubleshoot.replicated.com/v1beta1
+kind: Preflight
+metadata:
+  name: schemahero-preflights
+spec:
+  analyzers:
+    - clusterVersion:
+        outcomes:
+          - fail:
+              when: "< 1.13.0"
+              message: The application requires at Kubernetes 1.13.0 or later, and recommends 1.15.0.
+              uri: https://www.kubernetes.io
+          - warn:
+              when: "< 1.15.0"
+              message: Your cluster meets the minimum version of Kubernetes, but we recommend you update to 1.15.0 or later.
+              uri: https://kubernetes.io
+          - pass:
+              message: Your cluster meets the recommended and required versions of Kubernetes.

--- a/kots/replicated-app.yaml
+++ b/kots/replicated-app.yaml
@@ -1,0 +1,9 @@
+apiVersion: kots.io/v1beta1
+kind: Application
+metadata:
+  name: schemahero-enterprise
+spec:
+  title: SchemaHero Enterprise
+  icon: https://raw.githubusercontent.com/schemahero/schemahero-docs/0356662731945f066fe29be4a01edda481be277c/themes/hugo-whisper-theme/static/images/schemahero-logo.svga
+  releaseNotes: |
+    SchemaHero 0.8.0

--- a/kots/support-bundle.yaml
+++ b/kots/support-bundle.yaml
@@ -1,0 +1,32 @@
+apiVersion: troubleshoot.replicated.com/v1beta1
+kind: Collector
+metadata:
+  name: collector-sample
+spec:
+  collectors:
+    - clusterInfo: {}
+    - clusterResources: {}
+    - secret:
+        name: illmannered-cricket-mysql
+        namespace: default
+        key: mysql-password
+    - logs:
+        selector:
+          - name=nginx-ingress-microk8s
+        namespace: default
+        limits:
+          maxAge: 30d
+          maxLines: 10000
+    - run:
+        collectorName: ping-google
+        namespace: default
+        image: flungo/netutils
+        command: ["ping"]
+        args: ["www.google.com"]
+        timeout: 5s
+    - http:
+        collectorName: test-get
+        get:
+          url: https://api.staging.replicated.com/market/v1/echo/ip
+          insecureSkipVerify: false
+          headers: {}

--- a/pkg/cli/schemaherokubectlcli/install.go
+++ b/pkg/cli/schemaherokubectlcli/install.go
@@ -1,8 +1,11 @@
 package schemaherokubectlcli
 
 import (
+	"bytes"
 	"fmt"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 
 	"github.com/schemahero/schemahero/pkg/installer"
 	"github.com/spf13/cobra"
@@ -27,6 +30,7 @@ func InstallCmd() *cobra.Command {
 					os.Exit(1)
 				}
 			}
+
 			if v.GetBool("yaml") {
 				manifests, err := installer.GenerateOperatorYAML(v.GetString("extensions-api"))
 				if err != nil {
@@ -34,7 +38,27 @@ func InstallCmd() *cobra.Command {
 					return err
 				}
 
-				fmt.Printf("%s\n", manifests)
+				if v.GetString("out-dir") != "" {
+					if err := os.MkdirAll(v.GetString("out-dir"), 0755); err != nil {
+						fmt.Printf("Error: %s\n", err.Error())
+						return err
+					}
+
+					for filename, manifest := range manifests {
+						if err := ioutil.WriteFile(filepath.Join(v.GetString("out-dir"), filename), manifest, 0644); err != nil {
+							fmt.Printf("Error: %s\n", err.Error())
+							return err
+						}
+					}
+				} else {
+					// Write to stdout
+					multiDocResult := [][]byte{}
+					for _, manifest := range manifests {
+						multiDocResult = append(multiDocResult, manifest)
+					}
+
+					fmt.Println(string(bytes.Join(multiDocResult, []byte("\n---\n"))))
+				}
 				return nil
 			}
 			if err := installer.InstallOperator(); err != nil {
@@ -47,7 +71,8 @@ func InstallCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().Bool("yaml", false, "Is present, don't install the operator, just generate the yaml")
+	cmd.Flags().Bool("yaml", false, "If present, don't install the operator, just generate the yaml")
+	cmd.Flags().String("out-dir", "", "If present and --yaml also specified, write all of the manifests to this directory")
 	cmd.Flags().String("extensions-api", "", "version of apiextensions.k8s.io to generate. if unset, will detect best version from kubernetes version")
 
 	return cmd


### PR DESCRIPTION
Because the v1alpha3 schemahero no longer contains rendered, applyable YAML, this took a little code. 

In v1alpha3, the recommend installation path is either `kubectl schemahero install` or `kubectl. schemahero install --yaml | kubectl apply -f`.  This PR adds a flag that allows the second option to render the YAML to multiple files on disk. The GitHub action calls this, and renders these into a directory that contains the preflights, support-bundle, config, etc.  This will allow the KOTS application to be updated on PR.