### PR TITLE
Add namespace for compatibility with kots

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -97,7 +97,7 @@ jobs:
           path: bin/
       - run: chmod +x bin/kubectl-schemahero
 
-      - run: ./bin/kubectl-schemahero install --yaml --out-dir ./kots --enterprise
+      - run: ./bin/kubectl-schemahero install --yaml --out-dir=./kots --enterprise --namespace="repl{{ Namespace }}"
 
       - name: Lint the release
         id: lint-action

--- a/pkg/cli/schemaherokubectlcli/install.go
+++ b/pkg/cli/schemaherokubectlcli/install.go
@@ -32,7 +32,7 @@ func InstallCmd() *cobra.Command {
 			}
 
 			if v.GetBool("yaml") {
-				manifests, err := installer.GenerateOperatorYAML(v.GetString("extensions-api"), v.GetBool("enterprise"))
+				manifests, err := installer.GenerateOperatorYAML(v.GetString("extensions-api"), v.GetBool("enterprise"), v.GetString("namespace"))
 				if err != nil {
 					fmt.Printf("Error: %s\n", err.Error())
 					return err
@@ -61,7 +61,7 @@ func InstallCmd() *cobra.Command {
 				}
 				return nil
 			}
-			if err := installer.InstallOperator(v.GetBool("enterprise")); err != nil {
+			if err := installer.InstallOperator(v.GetBool("enterprise"), v.GetString("namespace")); err != nil {
 				fmt.Printf("Error: %s\n", err.Error())
 				return err
 			}
@@ -75,6 +75,7 @@ func InstallCmd() *cobra.Command {
 	cmd.Flags().String("out-dir", "", "If present and --yaml also specified, write all of the manifests to this directory")
 	cmd.Flags().String("extensions-api", "", "version of apiextensions.k8s.io to generate. if unset, will detect best version from kubernetes version")
 	cmd.Flags().Bool("enterprise", false, "If preset, generate enterprise YAML with KOTS template functions. This probably isn't what you want")
+	cmd.Flags().StringP("namespace", "n", "schemahero-system", "The namespace to install SchemaHero Operator into")
 
 	return cmd
 }


### PR DESCRIPTION
The namespace was static `schemahero-system`. This isn't great and it's not compatible with KOTS which prompts the user for a namespace.

This will use the new Namespace template function in KOTS to make it work.