### PR TITLE
Setting migration owner refs and apply pod names

### DIFF
--- a/hack/boilerplate.go.txt
+++ b/hack/boilerplate.go.txt
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Replicated, Inc.
+Copyright 2020 Replicated, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
This fixes #132 by using a unique name for each migration and also by using update when a config map already exists, include of assuming that create is the right command to run.

This needs a test...  I think an integration test should be added to cover this before merging to master.