### PR TITLE
Store last planned spec sha in status object

### DIFF
--- a/config/crds/v1/schemas.schemahero.io_tables.yaml
+++ b/config/crds/v1/schemas.schemahero.io_tables.yaml
@@ -272,6 +272,14 @@ spec:
             type: object
           status:
             description: TableStatus defines the observed state of Table
+            properties:
+              lastPlannedTableSpecSHA:
+                description: We store the SHA of the table spec from the last time
+                  we executed a plan to make startup less noisy by skipping re-planning
+                  objects that have been planned we cannot use the resourceVersion
+                  or generation fields because updating them would cause the object
+                  to be modified again
+                type: string
             type: object
         type: object
     served: true

--- a/config/crds/v1beta1/schemas.schemahero.io_tables.yaml
+++ b/config/crds/v1beta1/schemas.schemahero.io_tables.yaml
@@ -270,6 +270,14 @@ spec:
           type: object
         status:
           description: TableStatus defines the observed state of Table
+          properties:
+            lastPlannedTableSpecSHA:
+              description: We store the SHA of the table spec from the last time we
+                executed a plan to make startup less noisy by skipping re-planning
+                objects that have been planned we cannot use the resourceVersion or
+                generation fields because updating them would cause the object to
+                be modified again
+              type: string
           type: object
       type: object
   version: v1alpha4

--- a/pkg/apis/schemas/v1alpha4/table_types.go
+++ b/pkg/apis/schemas/v1alpha4/table_types.go
@@ -42,6 +42,11 @@ type TableSpec struct {
 
 // TableStatus defines the observed state of Table
 type TableStatus struct {
+	// We store the SHA of the table spec from the last time we executed a plan to
+	// make startup less noisy by skipping re-planning objects that have been planned
+	// we cannot use the resourceVersion or generation fields because updating them
+	// would cause the object to be modified again
+	LastPlannedTableSpecSHA string `json:"lastPlannedTableSpecSHA,omitempty" yaml:"lastPlannedTableSpecSHA,omitempty"`
 }
 
 // +genclient
@@ -71,7 +76,7 @@ func (t Table) GetSHA() (string, error) {
 	}
 
 	sum := sha256.Sum256(b)
-	return fmt.Sprintf("%x", sum)[:7], nil
+	return fmt.Sprintf("%x", sum), nil
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controller/table/reconcile_pod.go
+++ b/pkg/controller/table/reconcile_pod.go
@@ -111,6 +111,8 @@ func (r *ReconcileTable) reconcilePod(ctx context.Context, pod *corev1.Pod) (rec
 		return reconcile.Result{}, errors.Wrap(err, "failed to get sha of table")
 	}
 
+	tableSHA = tableSHA[:7]
+
 	desiredMigration := schemasv1alpha4.Migration{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "schemas.schemahero.io/v1alpha4",

--- a/pkg/installer/table_objects.go
+++ b/pkg/installer/table_objects.go
@@ -272,6 +272,14 @@ spec:
           type: object
         status:
           description: TableStatus defines the observed state of Table
+          properties:
+            lastPlannedTableSpecSHA:
+              description: We store the SHA of the table spec from the last time we
+                executed a plan to make startup less noisy by skipping re-planning
+                objects that have been planned we cannot use the resourceVersion or
+                generation fields because updating them would cause the object to
+                be modified again
+              type: string
           type: object
       type: object
   version: v1alpha4
@@ -560,6 +568,14 @@ spec:
             type: object
           status:
             description: TableStatus defines the observed state of Table
+            properties:
+              lastPlannedTableSpecSHA:
+                description: We store the SHA of the table spec from the last time
+                  we executed a plan to make startup less noisy by skipping re-planning
+                  objects that have been planned we cannot use the resourceVersion
+                  or generation fields because updating them would cause the object
+                  to be modified again
+                type: string
             type: object
         type: object
     served: true


### PR DESCRIPTION
This PR fixes #196 by adding a `lastPlannedTableSpecSHA` object to all table status subresources. When we've deployed a plan, the sha of the spec will be stored on the table object.

When the manager starts, it will still reconcile these objects, but exit early without deploying anything if the sha hasn't changed.