### PR TITLE
Add kubectl generate

### DIFF
--- a/pkg/cli/schemaherokubectlcli/generate.go
+++ b/pkg/cli/schemaherokubectlcli/generate.go
@@ -1,17 +1,13 @@
 package schemaherokubectlcli
 
 import (
-	"context"
+	"errors"
 	"fmt"
 	"os"
 
-	databasesclientv1alpha4 "github.com/schemahero/schemahero/pkg/client/schemaheroclientset/typed/databases/v1alpha4"
 	"github.com/schemahero/schemahero/pkg/generate"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
 func GenerateCmd() *cobra.Command {
@@ -26,52 +22,22 @@ func GenerateCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			v := viper.GetViper()
 
-			cfg, err := config.GetConfig()
-			if err != nil {
-				return err
+			if v.GetString("database") != "" {
+				// use a deployed database object
+				// and create a pod in the cluster to access it
+
+				// TODO
+				return errors.New("not implemented")
 			}
-
-			databasesClient, err := databasesclientv1alpha4.NewForConfig(cfg)
-			if err != nil {
-				return err
-			}
-
-			namespace := v.GetString("namespace")
-			if namespace == "" {
-				namespace = corev1.NamespaceDefault
-			}
-
-			ctx := context.Background()
-			database, err := databasesClient.Databases(namespace).Get(ctx, v.GetString("database"), metav1.GetOptions{})
-			if err != nil {
-				return err
-			}
-
-			driver := ""
-			connectionURI := ""
-
-			if database.Spec.Connection.Postgres != nil {
-				driver = "postgres"
-				connectionURI = database.Spec.Connection.Postgres.URI.Value
-			} else if database.Spec.Connection.Mysql != nil {
-				driver = "mysql"
-				connectionURI = database.Spec.Connection.Mysql.URI.Value
-			} else if database.Spec.Connection.CockroachDB != nil {
-				driver = "cockroachdb"
-				connectionURI = database.Spec.Connection.CockroachDB.URI.Value
-			}
-
-			// TODO support Vault
-			// TODO support non URI connection params
 
 			g := generate.Generator{
-				Driver:    driver,
-				URI:       connectionURI,
-				DBName:    database.Name,
+				Driver:    v.GetString("driver"),
+				URI:       v.GetString("uri"),
+				DBName:    v.GetString("dbname"),
 				OutputDir: v.GetString("output-dir"),
 			}
-
 			return g.RunSync()
+
 		},
 	}
 
@@ -81,7 +47,12 @@ func GenerateCmd() *cobra.Command {
 		cwd = "."
 	}
 
-	cmd.Flags().StringP("database", "d", "", "database name to generate table yaml for")
+	cmd.Flags().String("database", "", "database name to generate table yaml for")
+
+	cmd.Flags().String("uri", "", "connection string uri")
+	cmd.Flags().String("driver", "", "name of the database driver to run")
+	cmd.Flags().String("dbname", "", "schemahero database name to write in the yaml")
+
 	cmd.Flags().String("output-dir", cwd, "directory to write schema files to")
 
 	return cmd

--- a/pkg/cli/schemaherokubectlcli/generate.go
+++ b/pkg/cli/schemaherokubectlcli/generate.go
@@ -1,0 +1,88 @@
+package schemaherokubectlcli
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	databasesclientv1alpha4 "github.com/schemahero/schemahero/pkg/client/schemaheroclientset/typed/databases/v1alpha4"
+	"github.com/schemahero/schemahero/pkg/generate"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+func GenerateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "generate",
+		Short:         "",
+		Long:          `...`,
+		SilenceErrors: true,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			viper.BindPFlags(cmd.Flags())
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := viper.GetViper()
+
+			cfg, err := config.GetConfig()
+			if err != nil {
+				return err
+			}
+
+			databasesClient, err := databasesclientv1alpha4.NewForConfig(cfg)
+			if err != nil {
+				return err
+			}
+
+			namespace := v.GetString("namespace")
+			if namespace == "" {
+				namespace = corev1.NamespaceDefault
+			}
+
+			ctx := context.Background()
+			database, err := databasesClient.Databases(namespace).Get(ctx, v.GetString("database"), metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+
+			driver := ""
+			connectionURI := ""
+
+			if database.Spec.Connection.Postgres != nil {
+				driver = "postgres"
+				connectionURI = database.Spec.Connection.Postgres.URI.Value
+			} else if database.Spec.Connection.Mysql != nil {
+				driver = "mysql"
+				connectionURI = database.Spec.Connection.Mysql.URI.Value
+			} else if database.Spec.Connection.CockroachDB != nil {
+				driver = "cockroachdb"
+				connectionURI = database.Spec.Connection.CockroachDB.URI.Value
+			}
+
+			// TODO support Vault
+			// TODO support non URI connection params
+
+			g := generate.Generator{
+				Driver:    driver,
+				URI:       connectionURI,
+				DBName:    database.Name,
+				OutputDir: v.GetString("output-dir"),
+			}
+
+			return g.RunSync()
+		},
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		fmt.Printf("unable to get workdir: %s\n", err.Error())
+		cwd = "."
+	}
+
+	cmd.Flags().StringP("database", "d", "", "database name to generate table yaml for")
+	cmd.Flags().String("output-dir", cwd, "directory to write schema files to")
+
+	return cmd
+}

--- a/pkg/cli/schemaherokubectlcli/root.go
+++ b/pkg/cli/schemaherokubectlcli/root.go
@@ -40,6 +40,7 @@ func RootCmd() *cobra.Command {
 	cmd.AddCommand(DescribeCmd())
 	cmd.AddCommand(UpdateCmd())
 	cmd.AddCommand(ApproveCmd())
+	cmd.AddCommand(GenerateCmd())
 
 	viper.BindPFlags(cmd.Flags())
 


### PR DESCRIPTION
With this, you can deploy SchemaHero to a cluster, configure a database object and then:

```
kuebctl schemahero generate --database db-name --output-dir ./out/
```

And the CLI will generate table specs for all tables found in the database.

This _should_ be updated to not need the operator (currently needs a connection string, but this could be a CLI option)

This _should_ be updated to run a pod if the operator is present, because currently it requires client access to the database which can be tricky.
