### PR TITLE
Refactor manager to use cobra/viper

### DIFF
--- a/Dockerfile.manager
+++ b/Dockerfile.manager
@@ -24,4 +24,4 @@ RUN useradd -c 'schemahero-manager user' -m -d /home/schemahero-manager -s /bin/
 USER schemahero-manager
 ENV HOME /home/schemahero-manager
 
-ENTRYPOINT ["/manager"]
+ENTRYPOINT ["/manager", "run"]

--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,8 @@ bin/manager:
 		./cmd/manager
 
 .PHONY: run
-run: generate fmt vet bin/schemahero
-	go run ./cmd/manager/main.go
+run: generate fmt vet bin/schemahero bin/manager
+	./bin/manager run
 
 .PHONY: install
 install: manifests generate microk8s

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -1,77 +1,7 @@
-/*
-Copyright 2019 Replicated, Inc.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package main
 
-import (
-	"flag"
-	"os"
-
-	"github.com/schemahero/schemahero/pkg/apis"
-	"github.com/schemahero/schemahero/pkg/controller"
-	"github.com/schemahero/schemahero/pkg/logger"
-	"github.com/schemahero/schemahero/pkg/version"
-	"github.com/schemahero/schemahero/pkg/webhook"
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
-)
+import "github.com/schemahero/schemahero/pkg/cli/managercli"
 
 func main() {
-	var metricsAddr string
-	flag.StringVar(&metricsAddr, "metrics-addr", ":8088", "The address the metric endpoint binds to.")
-	flag.Parse()
-
-	logger.Infof("Starting schemahero version %+v", version.GetBuild())
-
-	// Get a config to talk to the apiserver
-	cfg, err := config.GetConfig()
-	if err != nil {
-		logger.Error(err)
-		os.Exit(1)
-	}
-
-	// Create a new Cmd to provide shared dependencies and start components
-	mgr, err := manager.New(cfg, manager.Options{MetricsBindAddress: metricsAddr})
-	if err != nil {
-		logger.Error(err)
-		os.Exit(1)
-	}
-
-	// Setup Scheme for all resources
-	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
-		logger.Error(err)
-		os.Exit(1)
-	}
-
-	// Setup all Controllers
-	if err := controller.AddToManager(mgr); err != nil {
-		logger.Error(err)
-		os.Exit(1)
-	}
-
-	if err := webhook.AddToManager(mgr); err != nil {
-		logger.Error(err)
-		os.Exit(1)
-	}
-
-	// Start the Cmd
-	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {
-		logger.Error(err)
-		os.Exit(1)
-	}
+	managercli.InitAndExecute()
 }

--- a/deploy/Dockerfile.manager
+++ b/deploy/Dockerfile.manager
@@ -7,4 +7,4 @@ RUN useradd -c 'schemahero-manager user' -m -d /home/schemahero-manager -s /bin/
 USER schemahero-manager
 ENV HOME /home/schemahero-manager
 
-ENTRYPOINT ["/manager"]
+ENTRYPOINT ["/manager", "run"]

--- a/pkg/cli/managercli/root.go
+++ b/pkg/cli/managercli/root.go
@@ -1,0 +1,56 @@
+package managercli
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+var (
+	kubernetesConfigFlags *genericclioptions.ConfigFlags
+)
+
+func RootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "manager",
+		Short: "SchemaHero is a cloud-native database schema management tool",
+		Long:  `...`,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			viper.BindPFlags(cmd.Flags())
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Help()
+			os.Exit(1)
+		},
+	}
+
+	cobra.OnInitialize(initConfig)
+
+	kubernetesConfigFlags = genericclioptions.NewConfigFlags(false)
+	kubernetesConfigFlags.AddFlags(cmd.PersistentFlags())
+
+	cmd.AddCommand(Version())
+	cmd.AddCommand(RunCmd())
+
+	viper.BindPFlags(cmd.Flags())
+
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+
+	return cmd
+}
+
+func InitAndExecute() {
+	if err := RootCmd().Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+func initConfig() {
+	viper.SetEnvPrefix("SCHEMAHERO")
+	viper.AutomaticEnv()
+}

--- a/pkg/cli/managercli/run.go
+++ b/pkg/cli/managercli/run.go
@@ -1,0 +1,78 @@
+package managercli
+
+import (
+	"os"
+
+	"github.com/schemahero/schemahero/pkg/apis"
+	"github.com/schemahero/schemahero/pkg/controller"
+	"github.com/schemahero/schemahero/pkg/logger"
+	"github.com/schemahero/schemahero/pkg/version"
+	"github.com/schemahero/schemahero/pkg/webhook"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+)
+
+func RunCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "run",
+		Short:         "runs the schemahero manager",
+		Long:          `...`,
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			viper.BindPFlags(cmd.Flags())
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			logger.Infof("Starting schemahero version %+v", version.GetBuild())
+
+			v := viper.GetViper()
+
+			// Get a config to talk to the apiserver
+			cfg, err := config.GetConfig()
+			if err != nil {
+				logger.Error(err)
+				os.Exit(1)
+			}
+
+			// Create a new Cmd to provide shared dependencies and start components
+			mgr, err := manager.New(cfg, manager.Options{MetricsBindAddress: v.GetString("metrics-addr")})
+			if err != nil {
+				logger.Error(err)
+				os.Exit(1)
+			}
+
+			// Setup Scheme for all resources
+			if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
+				logger.Error(err)
+				os.Exit(1)
+			}
+
+			// Setup all Controllers
+			if err := controller.AddToManager(mgr); err != nil {
+				logger.Error(err)
+				os.Exit(1)
+			}
+
+			if err := webhook.AddToManager(mgr); err != nil {
+				logger.Error(err)
+				os.Exit(1)
+			}
+
+			// Start the Cmd
+			if err := mgr.Start(signals.SetupSignalHandler()); err != nil {
+				logger.Error(err)
+				os.Exit(1)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().String("metrics-addr", ":8088", "The address the metric endpoint binds to.")
+
+	return cmd
+}

--- a/pkg/cli/managercli/version.go
+++ b/pkg/cli/managercli/version.go
@@ -1,0 +1,24 @@
+package managercli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/schemahero/schemahero/pkg/version"
+)
+
+func Version() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "version",
+		Short:         "manager version information",
+		Long:          `...`,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fmt.Printf("SchemaHero Manager %s\n", version.Version())
+			return nil
+		},
+	}
+
+	return cmd
+}


### PR DESCRIPTION
This is some light refactoring for two purposes:

1. the manager executable was "special" in schemahero. The other executables uses cobra and viper, while manager was just a main.go. This PR brings this binary into the "norm" for the project.

2. by doing this, the manager will support CLI flags and env vars so that it can run only a database, only a table, only a migration or a combination of these controllers to make it possible to run inline migrations and resolve #211 with a much larger refactor that's in progress.