### PR TITLE
pkg/cli/schemaherokubectlcli: handle walk error

### DIFF
--- a/pkg/cli/schemaherokubectlcli/apply.go
+++ b/pkg/cli/schemaherokubectlcli/apply.go
@@ -57,6 +57,9 @@ func ApplyCmd() *cobra.Command {
 			if fi.Mode().IsDir() {
 				commands := []string{}
 				err := filepath.Walk(v.GetString("ddl"), func(path string, info os.FileInfo, err error) error {
+					if err != nil {
+						return err
+					}
 					if info.IsDir() {
 						return nil
 					}


### PR DESCRIPTION
A function created for `filepath.Walk` in the `schemaherokubectlcli` package accepts an error as its third argument, but then does nothing with it. This change picks up the dropped error and returns it should it be non-nil.

What is supposed to be done with the `err` in that anonymous `func()` is sufficiently not-obvious that I link to a spot where I landed the same fix in `golang.org/x/tools`. https://go-review.googlesource.com/c/tools/+/203884/6/blog/blog.go
