### PR TITLE
Use Database name to retrieve Vault config

### DIFF
--- a/pkg/apis/databases/v1alpha4/vault_connection.go
+++ b/pkg/apis/databases/v1alpha4/vault_connection.go
@@ -137,7 +137,7 @@ func (d *Database) getVaultConnection(ctx context.Context, clientset *kubernetes
 		return "", "", errors.Wrap(err, "failed to unmarshal response")
 	}
 
-	req, err = http.NewRequest("GET", fmt.Sprintf("%s/v1/database/config/%s", valueOrValueFrom.ValueFrom.Vault.Endpoint, valueOrValueFrom.ValueFrom.Vault.Secret), nil)
+	req, err = http.NewRequest("GET", fmt.Sprintf("%s/v1/database/config/%s", valueOrValueFrom.ValueFrom.Vault.Endpoint, d.Name), nil)
 	if err != nil {
 		return "", "", errors.Wrap(err, "failed to create request")
 	}


### PR DESCRIPTION
The resource that lives at the path `/database/config/*` in the Vault
API is configuration for a specific database connection, so the name is
more likely to map to a specific Database object.

The `Secret` configured on the Database object is actually a mapping to a
`role` in Vault that provides specific permissions on a database (it's a
secret that happens to be creds for a Vault Db role).