### PR TITLE
fix(cli/generate): check for missing parameters

### DIFF
--- a/pkg/cli/schemaherokubectlcli/generate.go
+++ b/pkg/cli/schemaherokubectlcli/generate.go
@@ -21,10 +21,19 @@ func GenerateCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			v := viper.GetViper()
 
+			uri := v.GetString("uri")
+			driver := v.GetString("driver")
+			dbName := v.GetString("dbname")
+
+			if uri == "" || driver == "" || dbName == "" {
+				cmd.PrintErr("missing required parameters")
+				return cmd.Help()
+			}
+
 			g := generate.Generator{
-				Driver:    v.GetString("driver"),
-				URI:       v.GetString("uri"),
-				DBName:    v.GetString("dbname"),
+				Driver:    driver,
+				URI:       uri,
+				DBName:    dbName,
 				OutputDir: v.GetString("output-dir"),
 			}
 			return g.RunSync()
@@ -38,9 +47,9 @@ func GenerateCmd() *cobra.Command {
 		cwd = "."
 	}
 
-	cmd.Flags().String("uri", "", "connection string uri")
-	cmd.Flags().String("driver", "", "name of the database driver to run")
-	cmd.Flags().String("dbname", "", "schemahero database name to write in the yaml")
+	cmd.Flags().String("uri", "", "connection string uri (required)")
+	cmd.Flags().String("driver", "", "name of the database driver to run (required)")
+	cmd.Flags().String("dbname", "", "schemahero database name to write in the yaml (required)")
 
 	cmd.Flags().String("output-dir", cwd, "directory to write schema files to")
 

--- a/pkg/cli/schemaherokubectlcli/generate.go
+++ b/pkg/cli/schemaherokubectlcli/generate.go
@@ -51,6 +51,10 @@ func GenerateCmd() *cobra.Command {
 	cmd.Flags().String("driver", "", "name of the database driver to run (required)")
 	cmd.Flags().String("dbname", "", "schemahero database name to write in the yaml (required)")
 
+	cmd.MarkFlagRequired("uri")
+	cmd.MarkFlagRequired("driver")
+	cmd.MarkFlagRequired("dbname")
+
 	cmd.Flags().String("output-dir", cwd, "directory to write schema files to")
 
 	return cmd


### PR DESCRIPTION
This avoids a panic that happens later on when the URI and db is used but is nil.

closes #298