### PR TITLE
Use numeric USER in image

### DIFF
--- a/Dockerfile.manager
+++ b/Dockerfile.manager
@@ -9,7 +9,7 @@ RUN apt-get update \
 ADD ./bin/manager /manager
 
 RUN useradd -c 'schemahero user' -m -d /home/schemahero -s /bin/bash -u 1001 schemahero
-USER schemahero
+USER 1001
 ENV HOME /home/schemahero
 
 ENTRYPOINT ["/manager", "run"]


### PR DESCRIPTION
Kubernetes best practice recommends running pods as a non-root user. If
this is enforced by a `PodSecurityPolicy` then either the
`securityContext.runAsUser` must be set on the pod or the `USER`
directive used in the image, with a numeric value. See
https://kubernetes.io/docs/concepts/policy/pod-security-policy/#users-and-groups
for more info.

Signed-off-by: Paul Thomson <thomsonp83@gmail.com>