### PR TITLE
Update sqlite3 tests to be compatible with the latest sqlite3 image

### DIFF
--- a/integration/tests/sqlite/common.mk
+++ b/integration/tests/sqlite/common.mk
@@ -12,6 +12,8 @@ run:
 	touch ./db/db.db
 	docker pull keinos/sqlite3:latest
 	docker run --rm -v `pwd`/db:/db --name $(DATABASE_CONTAINER_NAME) keinos/sqlite3:latest sqlite3 /db/db.db
+	chmod a+w db   # give the "sqlite" user in the container permissions
+	chmod a+w db/db.db   # and permission to the file
 	docker run --rm -v `pwd`/db:/db -v `pwd`/fixtures.sql:/fixtures.sql --name $(DATABASE_CONTAINER_NAME) keinos/sqlite3:latest sqlite3 /db/db.db ".read /fixtures.sql"
 
 	# Plan


### PR DESCRIPTION
The sqlite3 image that we use in tests was updated to be non-root (yay!).

But this broke the filesystem permissions in how we structure the tests today.
This change gets the tests working again by chmod'ing the local, ephemeral directory on the host that's shared between container runs.

