### PR TITLE
Allow dependabot to check github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,11 @@
 ---
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:


### PR DESCRIPTION
@marccampbell Here's the same thing in #315 but for the GitHub actions.