### PR TITLE
Remove unnecessary if condition

### DIFF
--- a/pkg/apis/databases/v1alpha4/vault.go
+++ b/pkg/apis/databases/v1alpha4/vault.go
@@ -104,15 +104,9 @@ func (d *Database) GetVaultAnnotations() (map[string]string, error) {
 	} else {
 		switch db {
 		case "postgres", "cockroachdb":
-			if connTemplate == "" {
-				template = fmt.Sprintf(`
+			template = fmt.Sprintf(`
 {{- with secret "database/creds/%s" -}}
 postgres://{{ .Data.username }}:{{ .Data.password }}@postgres:5432/%s{{- end }}`, v.Role, d.Name)
-			} else {
-				template = fmt.Sprintf(`
-{{- with secret "database/creds/%s" -}}
-%s`, v.Role, connTemplate)
-			}
 
 		case "mysql":
 			template = fmt.Sprintf(`


### PR DESCRIPTION
Related to #317 and #312

Checking the connTemplate being empty isn't needed since it's inside an
`else` block already (where the `if` has already checked)

The logic here should be "if template is specified on the DB config, use
that, otherwise use defaults for each db engine"