### PR TITLE
Honor the image flag to shell

### DIFF
--- a/pkg/cli/schemaherokubectlcli/shell.go
+++ b/pkg/cli/schemaherokubectlcli/shell.go
@@ -28,7 +28,9 @@ func ShellCmd() *cobra.Command {
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		PreRun: func(cmd *cobra.Command, args []string) {
-			viper.BindPFlags(cmd.Flags())
+			if err := viper.BindPFlags(cmd.Flags()); err != nil {
+				panic(err)
+			}
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()

--- a/pkg/cli/schemaherokubectlcli/shell.go
+++ b/pkg/cli/schemaherokubectlcli/shell.go
@@ -77,8 +77,10 @@ func ShellCmd() *cobra.Command {
 			// podArgs := []string{}
 
 			if database.Spec.Connection.Postgres != nil {
-				// TODO versions
-				podImage = "postgres:11"
+				if podImage == "" {
+					// TODO versions
+					podImage = "postgres:11"
+				}
 
 				connectionURI, err := database.Spec.Connection.Postgres.URI.Read(clientset, namespace)
 				if err != nil {
@@ -89,8 +91,10 @@ func ShellCmd() *cobra.Command {
 					connectionURI,
 				}
 			} else if database.Spec.Connection.Mysql != nil {
-				// TODO versions
-				podImage = "mysql:latest"
+				if podImage == "" {
+					// TODO versions
+					podImage = "mysql:latest"
+				}
 
 				connectionURI, err := database.Spec.Connection.Mysql.URI.Read(clientset, namespace)
 				if err != nil {

--- a/pkg/shell/shell.go
+++ b/pkg/shell/shell.go
@@ -14,8 +14,8 @@ import (
 
 // StartShellPod will start a new pod in the namespace using the imagename
 // The command will be sleep infinity, so the exec will have to start the
-// destired command
-// the caller is respondible for cleaning up this pod
+// desired command
+// the caller is responsible for cleaning up this pod
 func StartShellPod(ctx context.Context, namespace string, imageName string) (string, error) {
 	pod := &corev1.Pod{
 		TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
Because the [default image](https://github.com/schemahero/schemahero/blob/v0.12.0-beta.2/pkg/cli/schemaherokubectlcli/shell.go#L81) for postgres is 11, and my database is 12, it is a hassle that `kubectl schemahero shell my-db` did not respect the `--image` flag provided to it (because using `\dt` from an 11 psql connected to a 12 database yields an error)

IJ pointed out the typos in the other `shell.go` while I was trying to figure out what was going on, so I fixed those, and it similarly advised that the error returned from `viper.BindPFlags` was going to /dev/null -- but those are in separate commits if you don't want them fixed