### PR TITLE
Unify URI versus valuesFrom handling

### DIFF
--- a/integration/tests/postgres/column-set-default/Dockerfile
+++ b/integration/tests/postgres/column-set-default/Dockerfile
@@ -1,7 +1,6 @@
 FROM postgres:10.7
 
 ENV POSTGRES_USER=schemahero
-ENV POSTGRES_PASSWORD=password
 ENV POSTGRES_DB=schemahero
 
 ## Insert fixtures

--- a/integration/tests/postgres/column-unset-default/Dockerfile
+++ b/integration/tests/postgres/column-unset-default/Dockerfile
@@ -1,7 +1,6 @@
 FROM postgres:10.7
 
 ENV POSTGRES_USER=schemahero
-ENV POSTGRES_PASSWORD=password
 ENV POSTGRES_DB=schemahero
 
 ## Insert fixtures

--- a/integration/tests/postgres/common.mk
+++ b/integration/tests/postgres/common.mk
@@ -2,7 +2,8 @@ SHELL := /bin/bash
 DATABASE_IMAGE_NAME := schemahero/database
 DATABASE_CONTAINER_NAME := schemahero-database
 DRIVER := postgres
-URI := postgres://schemahero:password@127.0.0.1:15432/schemahero?sslmode=disable
+POSTGRES_PASSWORD_URI := %21%40%23%24%25%5E%26%2A%28%29%7B%7D%27%22%3B
+URI := postgres://schemahero:$(POSTGRES_PASSWORD_URI)@127.0.0.1:15432/schemahero?sslmode=disable
 
 .PHONY: run
 run:
@@ -10,7 +11,8 @@ run:
 	docker pull postgres:$(PG_VERSION)
 	docker build -t $(DATABASE_IMAGE_NAME) .
 	@-docker rm -f $(DATABASE_CONTAINER_NAME) > /dev/null 2>&1 ||:
-	docker run -p 15432:5432 --rm -d --name $(DATABASE_CONTAINER_NAME) $(DATABASE_IMAGE_NAME)
+	# the $ is doubled due to make :-(
+	docker run -p 15432:5432 --rm -d -e POSTGRES_PASSWORD='!@#$$%^&*(){}'\''";' -e POSTGRES_HOST_AUTH_METHOD=md5 --name $(DATABASE_CONTAINER_NAME) $(DATABASE_IMAGE_NAME)
 	while ! docker exec $(DATABASE_CONTAINER_NAME) pg_isready --quiet; do sleep 1; done
 	@sleep 1
 

--- a/integration/tests/postgres/create-table/Dockerfile
+++ b/integration/tests/postgres/create-table/Dockerfile
@@ -1,7 +1,6 @@
 FROM postgres:10.7
 
 ENV POSTGRES_USER=schemahero
-ENV POSTGRES_PASSWORD=password
 ENV POSTGRES_DB=schemahero
 
 ## Insert fixtures

--- a/integration/tests/postgres/foreign-key-action/Dockerfile
+++ b/integration/tests/postgres/foreign-key-action/Dockerfile
@@ -1,7 +1,6 @@
 FROM postgres:10.7
 
 ENV POSTGRES_USER=schemahero
-ENV POSTGRES_PASSWORD=password
 ENV POSTGRES_DB=schemahero
 
 ## Insert fixtures

--- a/integration/tests/postgres/foreign-key-alter/Dockerfile
+++ b/integration/tests/postgres/foreign-key-alter/Dockerfile
@@ -1,7 +1,6 @@
 FROM postgres:10.7
 
 ENV POSTGRES_USER=schemahero
-ENV POSTGRES_PASSWORD=password
 ENV POSTGRES_DB=schemahero
 
 ## Insert fixtures

--- a/integration/tests/postgres/foreign-key-create/Dockerfile
+++ b/integration/tests/postgres/foreign-key-create/Dockerfile
@@ -1,7 +1,6 @@
 FROM postgres:10.7
 
 ENV POSTGRES_USER=schemahero
-ENV POSTGRES_PASSWORD=password
 ENV POSTGRES_DB=schemahero
 
 ## Insert fixtures

--- a/integration/tests/postgres/foreign-key-drop/Dockerfile
+++ b/integration/tests/postgres/foreign-key-drop/Dockerfile
@@ -1,7 +1,6 @@
 FROM postgres:10.7
 
 ENV POSTGRES_USER=schemahero
-ENV POSTGRES_PASSWORD=password
 ENV POSTGRES_DB=schemahero
 
 ## Insert fixtures

--- a/integration/tests/postgres/index-create/Dockerfile
+++ b/integration/tests/postgres/index-create/Dockerfile
@@ -1,7 +1,6 @@
 FROM postgres:10.7
 
 ENV POSTGRES_USER=schemahero
-ENV POSTGRES_PASSWORD=password
 ENV POSTGRES_DB=schemahero
 
 ## Insert fixtures

--- a/integration/tests/postgres/not-null-with-default/Dockerfile
+++ b/integration/tests/postgres/not-null-with-default/Dockerfile
@@ -1,7 +1,6 @@
 FROM postgres:10.7
 
 ENV POSTGRES_USER=schemahero
-ENV POSTGRES_PASSWORD=password
 ENV POSTGRES_DB=schemahero
 
 ## Insert fixtures

--- a/integration/tests/postgres/not-null/Dockerfile
+++ b/integration/tests/postgres/not-null/Dockerfile
@@ -1,7 +1,6 @@
 FROM postgres:10.7
 
 ENV POSTGRES_USER=schemahero
-ENV POSTGRES_PASSWORD=password
 ENV POSTGRES_DB=schemahero
 
 ## Insert fixtures

--- a/integration/tests/postgres/primary-key-add/Dockerfile
+++ b/integration/tests/postgres/primary-key-add/Dockerfile
@@ -1,7 +1,6 @@
 FROM postgres:10.7
 
 ENV POSTGRES_USER=schemahero
-ENV POSTGRES_PASSWORD=password
 ENV POSTGRES_DB=schemahero
 
 ## Insert fixtures

--- a/integration/tests/postgres/primary-key-drop/Dockerfile
+++ b/integration/tests/postgres/primary-key-drop/Dockerfile
@@ -1,7 +1,6 @@
 FROM postgres:10.7
 
 ENV POSTGRES_USER=schemahero
-ENV POSTGRES_PASSWORD=password
 ENV POSTGRES_DB=schemahero
 
 ## Insert fixtures

--- a/integration/tests/postgres/unique-constraint-add/Dockerfile
+++ b/integration/tests/postgres/unique-constraint-add/Dockerfile
@@ -1,7 +1,6 @@
 FROM postgres:10.7
 
 ENV POSTGRES_USER=schemahero
-ENV POSTGRES_PASSWORD=password
 ENV POSTGRES_DB=schemahero
 
 ## Insert fixtures

--- a/integration/tests/postgres/unique-constraint-drop/Dockerfile
+++ b/integration/tests/postgres/unique-constraint-drop/Dockerfile
@@ -1,7 +1,6 @@
 FROM postgres:10.7
 
 ENV POSTGRES_USER=schemahero
-ENV POSTGRES_PASSWORD=password
 ENV POSTGRES_DB=schemahero
 
 ## Insert fixtures

--- a/pkg/apis/databases/v1alpha4/connection.go
+++ b/pkg/apis/databases/v1alpha4/connection.go
@@ -19,6 +19,7 @@ package v1alpha4
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pkg/errors"
 	"github.com/schemahero/schemahero/pkg/config"
@@ -86,7 +87,8 @@ func (d Database) getConnectionFromParams(ctx context.Context) (string, string, 
 			return "", "", errors.Wrap(err, "failed to read postgres dbname")
 		}
 
-		uri = fmt.Sprintf("postgres://%s:%s@%s:%s/%s", user, password, hostname, port, dbname)
+		authInfo := url.UserPassword(user, password).String()
+		uri = fmt.Sprintf("postgres://%s@%s:%s/%s", authInfo, hostname, port, dbname)
 		if !d.Spec.Connection.Postgres.SSLMode.IsEmpty() {
 			sslMode, err := d.getValueFromValueOrValueFrom(ctx, driver, d.Spec.Connection.Postgres.SSLMode)
 			if err != nil {
@@ -120,7 +122,8 @@ func (d Database) getConnectionFromParams(ctx context.Context) (string, string, 
 			return "", "", errors.Wrap(err, "failed to read cockroachdb dbname")
 		}
 
-		uri = fmt.Sprintf("postgres://%s:%s@%s:%s/%s", user, password, hostname, port, dbname)
+		authInfo := url.UserPassword(user, password).String()
+		uri = fmt.Sprintf("postgres://%s@%s:%s/%s", authInfo, hostname, port, dbname)
 		if !d.Spec.Connection.CockroachDB.SSLMode.IsEmpty() {
 			sslMode, err := d.getValueFromValueOrValueFrom(ctx, driver, d.Spec.Connection.CockroachDB.SSLMode)
 			if err != nil {

--- a/pkg/apis/databases/v1alpha4/ssm_connection.go
+++ b/pkg/apis/databases/v1alpha4/ssm_connection.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+// getSSMConnection returns the driver, the resolved value, and any error
 func (d *Database) getSSMConnection(ctx context.Context, clientset *kubernetes.Clientset, driver string, valueOrValueFrom ValueOrValueFrom) (string, string, error) {
 	region := valueOrValueFrom.ValueFrom.SSM.Region
 	if region == "" {

--- a/pkg/apis/databases/v1alpha4/value_or_value_from.go
+++ b/pkg/apis/databases/v1alpha4/value_or_value_from.go
@@ -1,11 +1,7 @@
 package v1alpha4
 
 import (
-	"context"
-
 	"github.com/pkg/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 )
 
 type ValueOrValueFrom struct {
@@ -43,31 +39,4 @@ func (v *ValueOrValueFrom) GetVaultDetails() (*Vault, error) {
 	}
 
 	return nil, errors.New("No Vault secret configured")
-}
-
-func (v *ValueOrValueFrom) Read(clientset *kubernetes.Clientset, namespace string) (string, error) {
-	if v.Value != "" {
-		return v.Value, nil
-	}
-
-	if v.ValueFrom == nil {
-		return "", errors.New("value and valueFrom cannot both be nil/empty")
-	}
-
-	if v.ValueFrom.SecretKeyRef != nil {
-		secret, err := clientset.CoreV1().Secrets(namespace).Get(context.Background(), v.ValueFrom.SecretKeyRef.Name, metav1.GetOptions{})
-		if err != nil {
-			return "", errors.Wrap(err, "failed to get secret")
-		}
-
-		return string(secret.Data[v.ValueFrom.SecretKeyRef.Key]), nil
-	}
-
-	if v.ValueFrom.Vault != nil {
-		// this feels wrong, but also doesn't make sense to return a
-		// a URI ref as a connection URI?
-		return "", nil
-	}
-
-	return "", errors.New("unable to find supported valueFrom")
 }

--- a/pkg/apis/databases/v1alpha4/vault_connection.go
+++ b/pkg/apis/databases/v1alpha4/vault_connection.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+// getVaultConnection returns the driver, the resolved URI, or an error
 func (d *Database) getVaultConnection(ctx context.Context, clientset kubernetes.Interface, driver string, valueOrValueFrom ValueOrValueFrom) (string, string, error) {
 	// if the value is in vault and we are using the vault injector, just read the file
 	if valueOrValueFrom.ValueFrom.Vault.AgentInject {

--- a/pkg/cli/schemaherokubectlcli/shell.go
+++ b/pkg/cli/schemaherokubectlcli/shell.go
@@ -80,7 +80,7 @@ func ShellCmd() *cobra.Command {
 				// TODO versions
 				podImage = "postgres:11"
 
-				connectionURI, err := database.Spec.Connection.Postgres.URI.Read(clientset, namespace)
+				_, connectionURI, err := database.GetConnection(ctx)
 				if err != nil {
 					return err
 				}
@@ -92,7 +92,7 @@ func ShellCmd() *cobra.Command {
 				// TODO versions
 				podImage = "mysql:latest"
 
-				connectionURI, err := database.Spec.Connection.Mysql.URI.Read(clientset, namespace)
+				_, connectionURI, err := database.GetConnection(ctx)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
There are a couple of motivations here:

* previously the code would silently eat a bogus `map[string]string` lookup, which _thankfully_ showed up in my case as `user= database=my-db` in the logs but in the worst case of `secretKeyRef: { name: whatever, key: PGPASWORD }` will cause a very, very ugly `FATAL: password authentication failed` as the `map` dereference returns the empty string which schemahero was previously using verbatim
* trying to use `schemahero shell my-db` for a `type: Database` which used the `valuesFrom:` setup (instead of the `uri:`) caused a very weird error `value and valueFrom cannot both be nil/empty` because it tried to `.URI.Read()` on an `.IsEmpty()` URI
* finally, having `password=password` is fine for tutorials, but any password containing `@` or similar URL-unsafe characters will cheerfully :bomb: in both the `shell` and the for-real schema management process

  I needed(?) to mutate the integration suite to show that the change does what it is supposed to do, but I guess I can try to unwind that if it interferes with landing this change

This will interest #269 in that I believe it fixes that usage, also although I don't have an AWS SSM available to test it (same story for `vault`)
