### PR TITLE
Move krew releaser into separate step

### DIFF
--- a/.github/workflows/tagged-release.yaml
+++ b/.github/workflows/tagged-release.yaml
@@ -98,6 +98,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  krew:
+    runs-on: ubuntu-latest
+    needs:
+      - goreleaser
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Create new schemahero version in krew-index
         uses: rajatjindal/krew-release-bot@v0.0.39
         with:


### PR DESCRIPTION
This separates the goreleaser from the krew index step. If goreleaser succeeds but krew index fails, we can retry just that step now.