### PR TITLE
Don't change go.mod when installing tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,9 +127,9 @@ kind: bin/kubectl-schemahero manager
 
 .PHONY: contoller-gen
 controller-gen:
-ifeq (, $(shell which controller-gen))
-	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.0
-CONTROLLER_GEN=$(shell which controller-gen)
+ifeq (, $(shell which controller-gen)) 
+	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.0
+CONTROLLER_GEN=$(shell go env GOPATH)/bin/controller-gen
 else
 CONTROLLER_GEN=$(shell which controller-gen)
 endif
@@ -137,11 +137,7 @@ endif
 .PHONY: client-gen
 client-gen:
 ifeq (, $(shell which client-gen))
-	mkdir /tmp/cgen
-	cd /tmp/cgen; \
-		go mod init tmp; \
-	go get k8s.io/code-generator/cmd/client-gen@kubernetes-1.20.0
-	rm -rf /tmp/cgen
+	go install k8s.io/code-generator/cmd/client-gen@kubernetes-1.20.0
 CLIENT_GEN=$(shell go env GOPATH)/bin/client-gen
 else
 CLIENT_GEN=$(shell which client-gen)

--- a/Makefile
+++ b/Makefile
@@ -137,8 +137,12 @@ endif
 .PHONY: client-gen
 client-gen:
 ifeq (, $(shell which client-gen))
+	mkdir /tmp/cgen
+	cd /tmp/cgen; \
+		go mod init tmp; \
 	go get k8s.io/code-generator/cmd/client-gen@kubernetes-1.20.0
-CLIENT_GEN=$(shell which client-gen)
+	rm -rf /tmp/cgen
+CLIENT_GEN=$(shell go env GOPATH)/bin/client-gen
 else
 CLIENT_GEN=$(shell which client-gen)
 endif


### PR DESCRIPTION
These two binaries are used to generate code and are not imported by the
controller itself, and as such shouldn't modify the go.mod.

Recent versions of kubebuilder now make a similar change in the way it
generates the Makefile to not change the project's go.mod when using go
get to download these tools (see: https://github.com/kubernetes-sigs/kubebuilder/blob/b088d4eaca8a46225ecc13640e0c439dcee588a2/pkg/plugins/golang/v3/scaffolds/internal/templates/makefile.go#L157-L167)

Signed-off-by: Paul Thomson <pthomson@tyro.com>