### PR TITLE
build docker images binaries with CGO_ENABLED=0 too

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,8 +206,8 @@ release-tarballs:
 release: release-tarballs
 	# build the docker images for in-cluster
 
-	GOOS=linux GOARCH=amd64 make bin/manager
-	GOOS=linux GOARCH=amd64 make bin/kubectl-schemahero
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 make bin/manager
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 make bin/kubectl-schemahero
 	docker build -t schemahero/schemahero:${GITHUB_TAG} -f ./deploy/Dockerfile.schemahero .
 	docker build -t schemahero/schemahero-manager:${GITHUB_TAG} -f ./deploy/Dockerfile.manager .
 	docker push schemahero/schemahero:${GITHUB_TAG}


### PR DESCRIPTION
I tried running the full release command, and got this:
```
# build the docker images for in-cluster
GOOS=linux GOARCH=amd64 make bin/manager
make[1]: Entering directory '/home/laverya/go/src/github.com/schemahero/schemahero'
go build \
  -tags netgo -installsuffix netgo \
	-ldflags " -X github.com/schemahero/schemahero/pkg/version.version=`git describe --tags` -X github.com/schemahero/schemahero/pkg/version.gitSHA=`git rev-parse HEAD` -X github.com/schemahero/schemahero/pkg/version.buildTime=`date -u +"%Y-%m-%dT%H:%M:%SZ"` -w -extldflags \"-static\" " \
	-o bin/manager \
	./cmd/manager
# github.com/schemahero/schemahero/cmd/manager
/tmp/go-link-192284555/000014.o: In function `unixDlOpen':
/home/laverya/go/pkg/mod/github.com/mattn/go-sqlite3@v1.14.7/sqlite3-binding.c:40403: warning: Using 'dlopen' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/tmp/go-link-192284555/000002.o: In function `mygetgrouplist':
/home/laverya/.gvm/gos/go1.16.3/src/os/user/getgrouplist_unix.go:16: warning: Using 'getgrouplist' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/tmp/go-link-192284555/000001.o: In function `mygetgrgid_r':
/home/laverya/.gvm/gos/go1.16.3/src/os/user/cgo_lookup_unix.go:38: warning: Using 'getgrgid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/tmp/go-link-192284555/000001.o: In function `mygetgrnam_r':
/home/laverya/.gvm/gos/go1.16.3/src/os/user/cgo_lookup_unix.go:43: warning: Using 'getgrnam_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/tmp/go-link-192284555/000001.o: In function `mygetpwnam_r':
/home/laverya/.gvm/gos/go1.16.3/src/os/user/cgo_lookup_unix.go:33: warning: Using 'getpwnam_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/tmp/go-link-192284555/000001.o: In function `mygetpwuid_r':
/home/laverya/.gvm/gos/go1.16.3/src/os/user/cgo_lookup_unix.go:28: warning: Using 'getpwuid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
make[1]: Leaving directory '/home/laverya/go/src/github.com/schemahero/schemahero'
GOOS=linux GOARCH=amd64 make bin/kubectl-schemahero
make[1]: Entering directory '/home/laverya/go/src/github.com/schemahero/schemahero'
go build \
  -tags netgo -installsuffix netgo \
	-ldflags " -X github.com/schemahero/schemahero/pkg/version.version=`git describe --tags` -X github.com/schemahero/schemahero/pkg/version.gitSHA=`git rev-parse HEAD` -X github.com/schemahero/schemahero/pkg/version.buildTime=`date -u +"%Y-%m-%dT%H:%M:%SZ"` -w -extldflags \"-static\" " \
	-o bin/kubectl-schemahero \
	./cmd/kubectl-schemahero
# github.com/schemahero/schemahero/cmd/kubectl-schemahero
/tmp/go-link-563125343/000010.o: In function `unixDlOpen':
/home/laverya/go/pkg/mod/github.com/mattn/go-sqlite3@v1.14.7/sqlite3-binding.c:40403: warning: Using 'dlopen' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/tmp/go-link-563125343/000014.o: In function `mygetgrouplist':
/home/laverya/.gvm/gos/go1.16.3/src/os/user/getgrouplist_unix.go:16: warning: Using 'getgrouplist' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/tmp/go-link-563125343/000013.o: In function `mygetgrgid_r':
/home/laverya/.gvm/gos/go1.16.3/src/os/user/cgo_lookup_unix.go:38: warning: Using 'getgrgid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/tmp/go-link-563125343/000013.o: In function `mygetgrnam_r':
/home/laverya/.gvm/gos/go1.16.3/src/os/user/cgo_lookup_unix.go:43: warning: Using 'getgrnam_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/tmp/go-link-563125343/000013.o: In function `mygetpwnam_r':
/home/laverya/.gvm/gos/go1.16.3/src/os/user/cgo_lookup_unix.go:33: warning: Using 'getpwnam_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/tmp/go-link-563125343/000013.o: In function `mygetpwuid_r':
/home/laverya/.gvm/gos/go1.16.3/src/os/user/cgo_lookup_unix.go:28: warning: Using 'getpwuid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
built bin/kubectl-schemahero
make[1]: Leaving directory '/home/laverya/go/src/github.com/schemahero/schemahero'
```
I forgot to add CGO_ENABLED=0 for these binary builds in #512 🤦‍♂️ 