### PR TITLE
feat: allow setting psql/cockroachdb currentSchema

### DIFF
--- a/pkg/apis/databases/v1alpha4/cockroachdb_types.go
+++ b/pkg/apis/databases/v1alpha4/cockroachdb_types.go
@@ -19,10 +19,11 @@ package v1alpha4
 type CockroachDBConnection struct {
 	URI ValueOrValueFrom `json:"uri,omitempty"`
 
-	Host     ValueOrValueFrom `json:"host,omitempty"`
-	Port     ValueOrValueFrom `json:"port,omitempty"`
-	User     ValueOrValueFrom `json:"user,omitempty"`
-	Password ValueOrValueFrom `json:"password,omitempty"`
-	DBName   ValueOrValueFrom `json:"dbname,omitempty"`
-	SSLMode  ValueOrValueFrom `json:"sslmode,omitempty"`
+	Host          ValueOrValueFrom `json:"host,omitempty"`
+	Port          ValueOrValueFrom `json:"port,omitempty"`
+	User          ValueOrValueFrom `json:"user,omitempty"`
+	Password      ValueOrValueFrom `json:"password,omitempty"`
+	DBName        ValueOrValueFrom `json:"dbname,omitempty"`
+	SSLMode       ValueOrValueFrom `json:"sslmode,omitempty"`
+	CurrentSchema ValueOrValueFrom `json:"schema,omitempty"`
 }

--- a/pkg/apis/databases/v1alpha4/postgres_types.go
+++ b/pkg/apis/databases/v1alpha4/postgres_types.go
@@ -19,10 +19,11 @@ package v1alpha4
 type PostgresConnection struct {
 	URI ValueOrValueFrom `json:"uri,omitempty"`
 
-	Host     ValueOrValueFrom `json:"host,omitempty"`
-	Port     ValueOrValueFrom `json:"port,omitempty"`
-	User     ValueOrValueFrom `json:"user,omitempty"`
-	Password ValueOrValueFrom `json:"password,omitempty"`
-	DBName   ValueOrValueFrom `json:"dbname,omitempty"`
-	SSLMode  ValueOrValueFrom `json:"sslmode,omitempty"`
+	Host          ValueOrValueFrom `json:"host,omitempty"`
+	Port          ValueOrValueFrom `json:"port,omitempty"`
+	User          ValueOrValueFrom `json:"user,omitempty"`
+	Password      ValueOrValueFrom `json:"password,omitempty"`
+	DBName        ValueOrValueFrom `json:"dbname,omitempty"`
+	SSLMode       ValueOrValueFrom `json:"sslmode,omitempty"`
+	CurrentSchema ValueOrValueFrom `json:"schema,omitempty"`
 }


### PR DESCRIPTION
Postgres 9.4 and later use currentSchema, and cockroachdb uses search_path ironically to be equivalent to the postgres API.

Postgres docs: https://jdbc.postgresql.org/documentation/94/connect.html#connection-parameters
CockroachDB docs: https://www.cockroachlabs.com/docs/stable/sql-name-resolution.html#current-schema
Ref psql 9.4 change: https://stackoverflow.com/questions/4168689/is-it-possible-to-specify-the-schema-when-connecting-to-postgres-with-jdbc

Fixes #476

Signed-off-by: Patrick Lee Scott <pat@patscott.io>

--- 

I am not a Go developer, so I think these changes seem sufficient to support the feature but I'm not sure how to test it to validate. Also, there are a whole bunch of generated files that go along with it when I run `make` and I wasn't sure if I should commit those or the CI would handle that part.

I would like to add an integration test for this feature but wasn't sure how to do so yet.