### PR TITLE
feat: allow setting psql/cockroachdb currentSchema

### DIFF
--- a/pkg/apis/databases/v1alpha4/cockroachdb_types.go
+++ b/pkg/apis/databases/v1alpha4/cockroachdb_types.go
@@ -19,10 +19,11 @@ package v1alpha4
 type CockroachDBConnection struct {
 	URI ValueOrValueFrom `json:"uri,omitempty"`
 
-	Host     ValueOrValueFrom `json:"host,omitempty"`
-	Port     ValueOrValueFrom `json:"port,omitempty"`
-	User     ValueOrValueFrom `json:"user,omitempty"`
-	Password ValueOrValueFrom `json:"password,omitempty"`
-	DBName   ValueOrValueFrom `json:"dbname,omitempty"`
-	SSLMode  ValueOrValueFrom `json:"sslmode,omitempty"`
+	Host          ValueOrValueFrom `json:"host,omitempty"`
+	Port          ValueOrValueFrom `json:"port,omitempty"`
+	User          ValueOrValueFrom `json:"user,omitempty"`
+	Password      ValueOrValueFrom `json:"password,omitempty"`
+	DBName        ValueOrValueFrom `json:"dbname,omitempty"`
+	SSLMode       ValueOrValueFrom `json:"sslmode,omitempty"`
+	CurrentSchema ValueOrValueFrom `json:"schema,omitempty"`
 }

--- a/pkg/apis/databases/v1alpha4/connection.go
+++ b/pkg/apis/databases/v1alpha4/connection.go
@@ -89,12 +89,24 @@ func (d Database) getConnectionFromParams(ctx context.Context) (string, string, 
 
 		authInfo := url.UserPassword(user, password).String()
 		uri = fmt.Sprintf("postgres://%s@%s:%s/%s", authInfo, hostname, port, dbname)
+
+		queryStringCharacter := "?"
 		if !d.Spec.Connection.Postgres.SSLMode.IsEmpty() {
 			sslMode, err := d.getValueFromValueOrValueFrom(ctx, driver, d.Spec.Connection.Postgres.SSLMode)
 			if err != nil {
 				return "", "", errors.Wrap(err, "failed to read postgres ssl mode")
 			}
-			uri = fmt.Sprintf("%s?sslmode=%s", uri, sslMode)
+			uri = fmt.Sprintf("%s%ssslmode=%s", uri, queryStringCharacter, sslMode)
+			queryStringCharacter = "&"
+		}
+
+		if !d.Spec.Connection.Postgres.CurrentSchema.IsEmpty() {
+			currentSchema, err := d.getValueFromValueOrValueFrom(ctx, driver, d.Spec.Connection.CockroachDB.CurrentSchema)
+			if err != nil {
+				return "", "", errors.Wrap(err, "failed to read postgres currentSchema")
+			}
+			uri = fmt.Sprintf("%s%scurrentSchema=%s", uri, queryStringCharacter, currentSchema)
+			queryStringCharacter = "&"
 		}
 	} else if driver == "cockroachdb" {
 		hostname, err := d.getValueFromValueOrValueFrom(ctx, driver, d.Spec.Connection.CockroachDB.Host)
@@ -124,12 +136,24 @@ func (d Database) getConnectionFromParams(ctx context.Context) (string, string, 
 
 		authInfo := url.UserPassword(user, password).String()
 		uri = fmt.Sprintf("postgres://%s@%s:%s/%s", authInfo, hostname, port, dbname)
+
+		queryStringCharacter := "?"
 		if !d.Spec.Connection.CockroachDB.SSLMode.IsEmpty() {
 			sslMode, err := d.getValueFromValueOrValueFrom(ctx, driver, d.Spec.Connection.CockroachDB.SSLMode)
 			if err != nil {
 				return "", "", errors.Wrap(err, "failed to read cockroachdb ssl mode")
 			}
-			uri = fmt.Sprintf("%s?sslmode=%s", uri, sslMode)
+			uri = fmt.Sprintf("%s%ssslmode=%s", uri, queryStringCharacter, sslMode)
+			queryStringCharacter = "&"
+		}
+
+		if !d.Spec.Connection.Postgres.CurrentSchema.IsEmpty() {
+			currentSchema, err := d.getValueFromValueOrValueFrom(ctx, driver, d.Spec.Connection.CockroachDB.CurrentSchema)
+			if err != nil {
+				return "", "", errors.Wrap(err, "failed to read postgres currentSchema")
+			}
+			uri = fmt.Sprintf("%s%ssearch_path=%s", uri, queryStringCharacter, currentSchema)
+			queryStringCharacter = "&"
 		}
 	} else if driver == "cassandra" {
 		return "", "", errors.New("not implemented")

--- a/pkg/apis/databases/v1alpha4/postgres_types.go
+++ b/pkg/apis/databases/v1alpha4/postgres_types.go
@@ -19,10 +19,11 @@ package v1alpha4
 type PostgresConnection struct {
 	URI ValueOrValueFrom `json:"uri,omitempty"`
 
-	Host     ValueOrValueFrom `json:"host,omitempty"`
-	Port     ValueOrValueFrom `json:"port,omitempty"`
-	User     ValueOrValueFrom `json:"user,omitempty"`
-	Password ValueOrValueFrom `json:"password,omitempty"`
-	DBName   ValueOrValueFrom `json:"dbname,omitempty"`
-	SSLMode  ValueOrValueFrom `json:"sslmode,omitempty"`
+	Host          ValueOrValueFrom `json:"host,omitempty"`
+	Port          ValueOrValueFrom `json:"port,omitempty"`
+	User          ValueOrValueFrom `json:"user,omitempty"`
+	Password      ValueOrValueFrom `json:"password,omitempty"`
+	DBName        ValueOrValueFrom `json:"dbname,omitempty"`
+	SSLMode       ValueOrValueFrom `json:"sslmode,omitempty"`
+	CurrentSchema ValueOrValueFrom `json:"schema,omitempty"`
 }


### PR DESCRIPTION
Postgres 9.4 and later use currentSchema, and cockroachdb uses search_path ironically to be equivalent to the postgres API.

Postgres docs: https://jdbc.postgresql.org/documentation/94/connect.html\#connection-parameters
CockroachDB docs: https://www.cockroachlabs.com/docs/stable/sql-name-resolution.html\#current-schema
Ref psql 9.4 change: https://stackoverflow.com/questions/4168689/is-it-possible-to-specify-the-schema-when-connecting-to-postgres-with-jdbc

Fixes #476

Signed-off-by: Patrick Lee Scott <pat@patscott.io>

---

I am not a Go developer, so I think these changes seem sufficient to support the feature but I'm not sure how to test it to validate. Also, there are a whole bunch of generated files that go along with it when I run make and I wasn't sure if I should commit those or the CI would handle that part.

I would like to add an integration test for this feature but wasn't sure how to do so yet.