### PR TITLE
Reuse API clients to avoid requests timing out

### DIFF
--- a/pkg/cli/schemaherokubectlcli/get_migrations.go
+++ b/pkg/cli/schemaherokubectlcli/get_migrations.go
@@ -97,12 +97,7 @@ func GetMigrationsCmd() *cobra.Command {
 
 			rows := [][]string{}
 			for _, m := range matchingMigrations {
-				table, err := migration.TableFromMigration(context.Background(), &m)
-				if err != nil {
-					return err
-				}
-
-				database, err := migration.DatabaseFromTable(context.Background(), table)
+				table, err := migration.TableFromMigration(ctx, &m)
 				if err != nil {
 					return err
 				}
@@ -119,7 +114,7 @@ func GetMigrationsCmd() *cobra.Command {
 				if isIncluded {
 					rows = append(rows, []string{
 						m.Name,
-						database.Name,
+						table.Spec.Database,
 						table.Name,
 						timestampToAge(m.Status.PlannedAt),
 						timestampToAge(m.Status.ExecutedAt),


### PR DESCRIPTION
Creating a new API client in a tight loop causes API requests to fail with DNS lookup errors, at least on EKS clusters.

```
$ kubectl schemahero get migrations
.
.
.
failed to get database: Get "https://<REDACTED>.sk1.us-east-1.eks.amazonaws.com/apis/databases.schemahero.io/v1alpha4/namespaces/default/databases/mydb": dial tcp: lookup <REDACTED>.sk1.us-east-1.eks.amazonaws.com on 1.1.1.1:53: no such host
```