### PR TITLE
Support for mysql alter column add auto_increment attribute

### DIFF
--- a/integration/tests/mysql/auto-increment-add/expect.sql
+++ b/integration/tests/mysql/auto-increment-add/expect.sql
@@ -1,1 +1,1 @@
-alter table `users` modify column `id` int (11) not null auto_increment;
+set @max = (select coalesce(max(`id`), 0) + 1 from `users`); set @alter_statement = concat('alter table `users` change column `id` `id` int (11) not null auto_increment, auto_increment=', @max); prepare stmt from @alter_statement; execute stmt; deallocate prepare stmt;

--- a/integration/tests/mysql/auto-increment-add/fixtures.sql
+++ b/integration/tests/mysql/auto-increment-add/fixtures.sql
@@ -1,3 +1,6 @@
 create table users (
-  id integer primary key not null
+  id integer primary key not null,
+  name varchar(255) not null
 );
+
+insert into users values (0, 'zero'), (1, 'one'), (2, 'two');

--- a/integration/tests/mysql/auto-increment-add/specs/users.yaml
+++ b/integration/tests/mysql/auto-increment-add/specs/users.yaml
@@ -10,3 +10,7 @@ schema:
           notNull: true
         attributes:
           autoIncrement: true
+      - name: name
+        type: varchar(255)
+        constraints:
+          notNull: true

--- a/pkg/database/mysql/alter_test.go
+++ b/pkg/database/mysql/alter_test.go
@@ -303,7 +303,7 @@ func Test_AlterColumnStatment(t *testing.T) {
 				},
 			},
 			expectedStatements: []string{
-				"alter table `t` modify column `c` int (11) not null auto_increment",
+				"set @max = (select coalesce(max(`c`), 0) + 1 from `t`); set @alter_statement = concat('alter table `t` change column `c` `c` int (11) not null auto_increment, auto_increment=', @max); prepare stmt from @alter_statement; execute stmt; deallocate prepare stmt",
 			},
 		},
 		{

--- a/pkg/database/mysql/connection.go
+++ b/pkg/database/mysql/connection.go
@@ -2,6 +2,7 @@ package mysql
 
 import (
 	"database/sql"
+	"net/url"
 	"strings"
 
 	// import the mysql driver
@@ -28,6 +29,12 @@ func (m *MysqlConnection) EngineVersion() string {
 }
 
 func Connect(uri string) (*MysqlConnection, error) {
+	var err error
+	uri, err = ensureMultiStatementsTrue(uri)
+	if err != nil {
+		return nil, err
+	}
+
 	db, err := sql.Open("mysql", uri)
 	if err != nil {
 		return nil, err
@@ -111,4 +118,15 @@ func PortFromURI(uri string) (string, error) {
 		return addrAndPort[1], nil
 	}
 	return "3306", nil
+}
+
+func ensureMultiStatementsTrue(uri string) (string, error) {
+	parsed, err := url.Parse(uri)
+	if err != nil {
+		return uri, err
+	}
+	query := parsed.Query()
+	query.Set("multiStatements", "true")
+	parsed.RawQuery = query.Encode()
+	return parsed.String(), nil
 }

--- a/pkg/database/mysql/connection_test.go
+++ b/pkg/database/mysql/connection_test.go
@@ -30,3 +30,28 @@ func Test_DatabaseNameFromURI(t *testing.T) {
 		})
 	}
 }
+
+func Test_ensureMultiStatementsTrue(t *testing.T) {
+	tests := []struct {
+		uri      string
+		expected string
+		wantErr  bool
+	}{
+		{
+			uri:      "username:password@tcp(host:3306)/dbname?tls=false",
+			expected: "username:password@tcp(host:3306)/dbname?multiStatements=true&tls=false",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.uri, func(t *testing.T) {
+			got, err := ensureMultiStatementsTrue(tt.uri)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ensureMultiStatementsTrue() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.expected {
+				t.Errorf("ensureMultiStatementsTrue() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Altering a column and adding auto_increment when a table is not empty gives error `Error 1062: ALTER TABLE causes auto_increment resequencing, resulting in duplicate entry '1' for key`. This relies on prepared statements to add auto_increment with increment value transactionally. A connection with `multiStatements=true` is required.