### PR TITLE
feat: improved kubectl print

### DIFF
--- a/config/crds/v1/databases.schemahero.io_databases.yaml
+++ b/config/crds/v1/databases.schemahero.io_databases.yaml
@@ -16,7 +16,19 @@ spec:
     singular: database
   scope: Namespaced
   versions:
-  - name: v1alpha4
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.namespace
+      name: Namespace
+      priority: 1
+      type: string
+    - jsonPath: .spec.immediateDeploy
+      name: Deploy Immediately
+      priority: 1
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha4
     schema:
       openAPIV3Schema:
         description: Database is the Schema for the databases API
@@ -2350,6 +2362,7 @@ spec:
               enableShellCommand:
                 type: boolean
               immediateDeploy:
+                default: false
                 type: boolean
               schemahero:
                 properties:

--- a/config/crds/v1/schemas.schemahero.io_migrations.yaml
+++ b/config/crds/v1/schemas.schemahero.io_migrations.yaml
@@ -16,7 +16,24 @@ spec:
     singular: migration
   scope: Namespaced
   versions:
-  - name: v1alpha4
+  - additionalPrinterColumns:
+    - jsonPath: .spec.databaseName
+      name: Database
+      type: string
+    - jsonPath: .spec.tableName
+      name: Table
+      type: string
+    - jsonPath: .metadata.namespace
+      name: Namespace
+      priority: 1
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha4
     schema:
       openAPIV3Schema:
         description: Migration is the Schema for the migrations API
@@ -36,6 +53,8 @@ spec:
           spec:
             description: MigrationSpec defines the desired state of Migration
             properties:
+              databaseName:
+                type: string
               editedDDL:
                 type: string
               generatedDDL:
@@ -45,6 +64,7 @@ spec:
               tableNamespace:
                 type: string
             required:
+            - databaseName
             - tableName
             - tableNamespace
             type: object
@@ -62,6 +82,13 @@ spec:
                   was determined to be invalid or outdated
                 format: int64
                 type: integer
+              phase:
+                enum:
+                - PLANNED
+                - APPROVED
+                - EXECUTED
+                - INVALID
+                type: string
               plannedAt:
                 description: PlannedAt is the unix nano timestamp when the plan was
                   generated
@@ -70,10 +97,13 @@ spec:
               rejectedAt:
                 format: int64
                 type: integer
+            required:
+            - phase
             type: object
         type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/crds/v1/schemas.schemahero.io_tables.yaml
+++ b/config/crds/v1/schemas.schemahero.io_tables.yaml
@@ -16,7 +16,21 @@ spec:
     singular: table
   scope: Namespaced
   versions:
-  - name: v1alpha4
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.namespace
+      name: Namespace
+      priority: 1
+      type: string
+    - jsonPath: .spec.name
+      name: Table
+      type: string
+    - jsonPath: .spec.database
+      name: Database
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha4
     schema:
       openAPIV3Schema:
         description: Table is the Schema for the tables API
@@ -512,6 +526,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/pkg/apis/databases/v1alpha4/database_types.go
+++ b/pkg/apis/databases/v1alpha4/database_types.go
@@ -37,9 +37,11 @@ type SchemaHero struct {
 type DatabaseSpec struct {
 	Connection         DatabaseConnection `json:"connection,omitempty"`
 	EnableShellCommand bool               `json:"enableShellCommand,omitempty"`
-	ImmediateDeploy    bool               `json:"immediateDeploy,omitempty"`
-	SchemaHero         *SchemaHero        `json:"schemahero,omitempty"`
-	Template           *DatabaseTemplate  `json:"template,omitempty"`
+
+	//+kubebuilder:default:=false
+	ImmediateDeploy bool              `json:"immediateDeploy,omitempty"`
+	SchemaHero      *SchemaHero       `json:"schemahero,omitempty"`
+	Template        *DatabaseTemplate `json:"template,omitempty"`
 }
 
 type DatabaseTemplate struct {
@@ -56,6 +58,9 @@ type DatabaseStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Database is the Schema for the databases API
+// +kubebuilder:printcolumn:name="Namespace",type=string,JSONPath=`.metadata.namespace`,priority=1
+// +kubebuilder:printcolumn:name="Deploy Immediately",type=boolean,JSONPath=`.spec.immediateDeploy`,priority=1
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
 type Database struct {

--- a/pkg/apis/schemas/v1alpha4/migration_types.go
+++ b/pkg/apis/schemas/v1alpha4/migration_types.go
@@ -20,8 +20,19 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// +kubebuilder:validation:Enum=PLANNED;APPROVED;EXECUTED;INVALID
+type Phase string
+
+const (
+	Planned  Phase = "PLANNED"
+	Approved Phase = "APPROVED"
+	Executed Phase = "EXECUTED"
+	Invalid  Phase = "INVALID"
+)
+
 // MigrationSpec defines the desired state of Migration
 type MigrationSpec struct {
+	DatabaseName   string `json:"databaseName,omitempty"`
 	TableName      string `json:"tableName"`
 	TableNamespace string `json:"tableNamespace"`
 	GeneratedDDL   string `json:"generatedDDL,omitempty"`
@@ -30,6 +41,8 @@ type MigrationSpec struct {
 
 // MigrationStatus defines the observed state of Migration
 type MigrationStatus struct {
+	Phase Phase `json:"phase,omitempty"`
+
 	// PlannedAt is the unix nano timestamp when the plan was generated
 	PlannedAt int64 `json:"plannedAt,omitempty"`
 
@@ -38,7 +51,6 @@ type MigrationStatus struct {
 
 	ApprovedAt int64 `json:"approvedAt,omitempty"`
 	RejectedAt int64 `json:"rejectedAt,omitempty"`
-
 	ExecutedAt int64 `json:"executedAt,omitempty"`
 }
 
@@ -46,6 +58,11 @@ type MigrationStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Migration is the Schema for the migrations API
+// +kubebuilder:printcolumn:name="Database",type=string,JSONPath=`.spec.databaseName`
+// +kubebuilder:printcolumn:name="Table",type=string,JSONPath=`.spec.tableName`
+// +kubebuilder:printcolumn:name="Namespace",type=string,JSONPath=`.metadata.namespace`,priority=1
+// +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +k8s:openapi-gen=true
 type Migration struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/apis/schemas/v1alpha4/table_types.go
+++ b/pkg/apis/schemas/v1alpha4/table_types.go
@@ -55,6 +55,10 @@ type TableStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Table is the Schema for the tables API
+// +kubebuilder:printcolumn:name="Namespace",type=string,JSONPath=`.metadata.namespace`,priority=1
+// +kubebuilder:printcolumn:name="Table",type=string,JSONPath=`.spec.name`
+// +kubebuilder:printcolumn:name="Database",type=string,JSONPath=`.spec.database`
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +k8s:openapi-gen=true
 type Table struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/cli/schemaherokubectlcli/approve_migration.go
+++ b/pkg/cli/schemaherokubectlcli/approve_migration.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/schemahero/schemahero/pkg/apis/schemas/v1alpha4"
 	schemasclientv1alpha4 "github.com/schemahero/schemahero/pkg/client/schemaheroclientset/typed/schemas/v1alpha4"
 	"github.com/schemahero/schemahero/pkg/config"
 	"github.com/spf13/cobra"
@@ -76,6 +77,7 @@ func ApproveMigrationCmd() *cobra.Command {
 				}
 
 				migration.Status.ApprovedAt = time.Now().Unix()
+				migration.Status.Phase = v1alpha4.Approved
 				if _, err := schemasClient.Migrations(namespaceName).Update(ctx, migration, metav1.UpdateOptions{}); err != nil {
 					return err
 				}

--- a/pkg/controller/migration/reconcile_migration.go
+++ b/pkg/controller/migration/reconcile_migration.go
@@ -48,6 +48,7 @@ func (r *ReconcileMigration) reconcileMigration(ctx context.Context, instance *s
 
 		// update the status to applied
 		instance.Status.ExecutedAt = time.Now().Unix()
+		instance.Status.Phase = schemasv1alpha4.Executed
 		err = r.Update(context.Background(), instance)
 
 		if err != nil {
@@ -62,8 +63,9 @@ func (r *ReconcileMigration) reconcileMigration(ctx context.Context, instance *s
 				}
 
 				updatedInstance.Status.ExecutedAt = time.Now().Unix()
+				instance.Status.Phase = schemasv1alpha4.Executed
 				if err := r.Update(context.Background(), updatedInstance); err != nil {
-					return reconcile.Result{}, errors.Wrap(err, "failed to udpate")
+					return reconcile.Result{}, errors.Wrap(err, "failed to update")
 				}
 			} else {
 				return reconcile.Result{}, err

--- a/pkg/controller/table/reconile_table.go
+++ b/pkg/controller/table/reconile_table.go
@@ -195,16 +195,19 @@ func (r *ReconcileTable) plan(ctx context.Context, databaseInstance *databasesv1
 		},
 		Spec: schemasv1alpha4.MigrationSpec{
 			GeneratedDDL:   generatedDDL,
+			DatabaseName:   tableInstance.Spec.Database,
 			TableName:      tableInstance.Name,
 			TableNamespace: tableInstance.Namespace,
 		},
 		Status: schemasv1alpha4.MigrationStatus{
 			PlannedAt: time.Now().Unix(),
+			Phase:     schemasv1alpha4.Planned,
 		},
 	}
 
 	if databaseInstance.Spec.ImmediateDeploy {
 		migration.Status.ApprovedAt = time.Now().Unix()
+		migration.Status.Phase = schemasv1alpha4.Planned
 	}
 
 	var existingMigration schemasv1alpha4.Migration

--- a/pkg/installer/database_objects.go
+++ b/pkg/installer/database_objects.go
@@ -18,7 +18,19 @@ spec:
     singular: database
   scope: Namespaced
   versions:
-  - name: v1alpha4
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.namespace
+      name: Namespace
+      priority: 1
+      type: string
+    - jsonPath: .spec.immediateDeploy
+      name: Deploy Immediately
+      priority: 1
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha4
     schema:
       openAPIV3Schema:
         description: Database is the Schema for the databases API
@@ -2352,6 +2364,7 @@ spec:
               enableShellCommand:
                 type: boolean
               immediateDeploy:
+                default: false
                 type: boolean
               schemahero:
                 properties:

--- a/pkg/installer/migration_objects.go
+++ b/pkg/installer/migration_objects.go
@@ -18,7 +18,24 @@ spec:
     singular: migration
   scope: Namespaced
   versions:
-  - name: v1alpha4
+  - additionalPrinterColumns:
+    - jsonPath: .spec.databaseName
+      name: Database
+      type: string
+    - jsonPath: .spec.tableName
+      name: Table
+      type: string
+    - jsonPath: .metadata.namespace
+      name: Namespace
+      priority: 1
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha4
     schema:
       openAPIV3Schema:
         description: Migration is the Schema for the migrations API
@@ -38,6 +55,8 @@ spec:
           spec:
             description: MigrationSpec defines the desired state of Migration
             properties:
+              databaseName:
+                type: string
               editedDDL:
                 type: string
               generatedDDL:
@@ -47,6 +66,7 @@ spec:
               tableNamespace:
                 type: string
             required:
+            - databaseName
             - tableName
             - tableNamespace
             type: object
@@ -64,6 +84,13 @@ spec:
                   was determined to be invalid or outdated
                 format: int64
                 type: integer
+              phase:
+                enum:
+                - PLANNED
+                - APPROVED
+                - EXECUTED
+                - INVALID
+                type: string
               plannedAt:
                 description: PlannedAt is the unix nano timestamp when the plan was
                   generated
@@ -72,10 +99,13 @@ spec:
               rejectedAt:
                 format: int64
                 type: integer
+            required:
+            - phase
             type: object
         type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/pkg/installer/table_objects.go
+++ b/pkg/installer/table_objects.go
@@ -18,7 +18,21 @@ spec:
     singular: table
   scope: Namespaced
   versions:
-  - name: v1alpha4
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.namespace
+      name: Namespace
+      priority: 1
+      type: string
+    - jsonPath: .spec.name
+      name: Table
+      type: string
+    - jsonPath: .spec.database
+      name: Database
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha4
     schema:
       openAPIV3Schema:
         description: Table is the Schema for the tables API
@@ -514,6 +528,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
Resolve #136. First attempt at some useful fields.

Timestamps will need to be a breaking change to use metav1.Time. I tried to list the Engine but kube JSONPath only supports simple paths and not the complete syntax. This will also have to be another field in the CRD. 
```
❯ k get database -owide
NAME      NAMESPACE   DEPLOY IMMEDIATELY   AGE
test-db   default     false                12d
```
```
❯ k get table -owide
NAME      NAMESPACE   TABLE     DATABASE   AGE
airport   default     airport   test-db    7m36s
```
```
❯ k get migration -owide
NAME      DATABASE   TABLE     NAMESPACE   PHASE     AGE
a8a8fd0   test-db    airport   default     PLANNED   6s
```