### PR TITLE
Fixes for collation and charset in mysql

### DIFF
--- a/integration/tests/mysql/Makefile
+++ b/integration/tests/mysql/Makefile
@@ -31,6 +31,9 @@ run: 5.6.51 5.7.33 8.0.23
 	make -C add-charset run
 	make -C add-collation run
 	make -C remove-charset run
+	make -C add-charset run
+	make -C create-with-charset run
+	make -C no-modify-charset run
 
 .PHONY: 5.7.33
 5.7.33: export MYSQL_VERSION = 5.7.33
@@ -56,6 +59,9 @@ run: 5.6.51 5.7.33 8.0.23
 	make -C add-charset run
 	make -C add-collation run
 	make -C remove-charset run
+	make -C add-charset run
+	make -C create-with-charset run
+	make -C no-modify-charset run
 
 .PHONY: 8.0.23
 8.0.23: export MYSQL_VERSION = 8.0.23
@@ -82,6 +88,9 @@ run: 5.6.51 5.7.33 8.0.23
 	make -C add-charset run
 	make -C add-collation run
 	make -C remove-charset run
+	make -C add-charset run
+	make -C create-with-charset run
+	make -C no-modify-charset run
 
 .PHONY: build
 build: docker-build

--- a/integration/tests/mysql/create-with-charset/Dockerfile
+++ b/integration/tests/mysql/create-with-charset/Dockerfile
@@ -1,0 +1,9 @@
+FROM mysql:8.0
+
+ENV MYSQL_USER=schemahero
+ENV MYSQL_PASSWORD=password
+ENV MYSQL_DATABASE=schemahero
+ENV MYSQL_RANDOM_ROOT_PASSWORD=1
+
+## Insert fixtures
+COPY ./fixtures.sql /docker-entrypoint-initdb.d/

--- a/integration/tests/mysql/create-with-charset/Makefile
+++ b/integration/tests/mysql/create-with-charset/Makefile
@@ -1,0 +1,4 @@
+include ../common.mk
+
+TEST_NAME := mysql-create-with-charset
+SPEC_FILE := ./specs/projects.yaml

--- a/integration/tests/mysql/create-with-charset/expect.sql
+++ b/integration/tests/mysql/create-with-charset/expect.sql
@@ -1,0 +1,1 @@
+create table `projects` (`id` int (11) not null, `name` text character set utf8mb4 null, primary key (`id`)) default character set utf16;

--- a/integration/tests/mysql/create-with-charset/fixtures.sql
+++ b/integration/tests/mysql/create-with-charset/fixtures.sql
@@ -1,0 +1,5 @@
+create table other (
+  id integer primary key not null,
+  email varchar(255) not null
+);
+

--- a/integration/tests/mysql/create-with-charset/specs/projects.yaml
+++ b/integration/tests/mysql/create-with-charset/specs/projects.yaml
@@ -1,0 +1,16 @@
+database: schemahero
+name: projects
+schema:
+  mysql:
+    primaryKey: [id]
+    defaultCharset: utf16
+    columns:
+      - name: id
+        type: integer
+        constraints:
+          notNull: true
+      - name: name
+        charset: utf8mb4
+        type: text (65535)
+        constraints:
+          notNull: false

--- a/integration/tests/mysql/no-modify-charset/Dockerfile
+++ b/integration/tests/mysql/no-modify-charset/Dockerfile
@@ -1,0 +1,9 @@
+FROM mysql:8.0
+
+ENV MYSQL_USER=schemahero
+ENV MYSQL_PASSWORD=password
+ENV MYSQL_DATABASE=schemahero
+ENV MYSQL_RANDOM_ROOT_PASSWORD=1
+
+## Insert fixtures
+COPY ./fixtures.sql /docker-entrypoint-initdb.d/

--- a/integration/tests/mysql/no-modify-charset/Makefile
+++ b/integration/tests/mysql/no-modify-charset/Makefile
@@ -1,0 +1,4 @@
+include ../common.mk
+
+TEST_NAME := mysql-no-modify-charset
+SPEC_FILE := ./specs/projects.yaml

--- a/integration/tests/mysql/no-modify-charset/expect.sql
+++ b/integration/tests/mysql/no-modify-charset/expect.sql
@@ -1,0 +1,1 @@
+alter table `projects` add column `newcol` int (11);

--- a/integration/tests/mysql/no-modify-charset/expect.sql
+++ b/integration/tests/mysql/no-modify-charset/expect.sql
@@ -1,1 +1,1 @@
-alter table `projects` add column `newcol` int (11);
+alter table `projects` modify column `name` text character set utf8mb4 null;

--- a/integration/tests/mysql/no-modify-charset/fixtures.sql
+++ b/integration/tests/mysql/no-modify-charset/fixtures.sql
@@ -1,0 +1,5 @@
+create table `projects` (
+  `id` int (11) not null,
+  `name` text character set utf8mb4 null,
+  primary key (`id`)
+) default character set utf16;

--- a/integration/tests/mysql/no-modify-charset/specs/projects.yaml
+++ b/integration/tests/mysql/no-modify-charset/specs/projects.yaml
@@ -1,0 +1,18 @@
+database: schemahero
+name: projects
+schema:
+  mysql:
+    primaryKey: [id]
+    defaultCharset: utf16
+    columns:
+      - name: id
+        type: integer
+        constraints:
+          notNull: true
+      - name: name
+        charset: utf8mb4
+        type: text (65535)
+        constraints:
+          notNull: false
+      - name: newcol
+        type: int

--- a/pkg/database/mysql/alter_statements.go
+++ b/pkg/database/mysql/alter_statements.go
@@ -42,7 +42,12 @@ func (s AlterModifyColumnStatement) ddl(useConstraintsFromExistingColumn bool) [
 	}
 
 	if s.Column.Charset != s.ExistingColumn.Charset || s.Column.Collation != s.ExistingColumn.Collation {
-		stmts = append(stmts, fmt.Sprintf("character set %s collate %s", s.Column.Charset, s.Column.Collation))
+		stmt := fmt.Sprintf("character set %s", s.Column.Charset)
+		if s.Column.Collation != "" {
+			stmt = fmt.Sprintf("%s collate %s", stmt, s.Column.Collation)
+		}
+
+		stmts = append(stmts, stmt)
 	}
 
 	if useConstraintsFromExistingColumn {


### PR DESCRIPTION
Fixes #622 and Fixes #621

This addresses two issues (there are more still):

1. Table collation and charset were being overwritten because we were comparing "existing" and "desired" too early in the function. Moving this code down has stopped generating a statement that is essentially a no-op
2. When a column has a charset and no collation, were were producing invalid DDL. This is now valid (and a no-op). Really this second statement should not be created either, and we need to plan to make sure that it's not generated.

After this fix, all collation and charset changes should at least generate valid DDL.