### PR TITLE
Support for multiline strings in seed data

### DIFF
--- a/config/crds/v1/schemas.schemahero.io_tables.yaml
+++ b/config/crds/v1/schemas.schemahero.io_tables.yaml
@@ -513,16 +513,28 @@ spec:
                   rows:
                     items:
                       properties:
-                        column:
-                          type: string
-                        value:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          x-kubernetes-int-or-string: true
+                        columns:
+                          items:
+                            properties:
+                              column:
+                                type: string
+                              value:
+                                properties:
+                                  int:
+                                    type: integer
+                                  str:
+                                    type: string
+                                required:
+                                - int
+                                - str
+                                type: object
+                            required:
+                            - column
+                            - value
+                            type: object
+                          type: array
                       required:
-                      - column
-                      - value
+                      - columns
                       type: object
                     type: array
                 required:

--- a/integration/tests/mysql/Makefile
+++ b/integration/tests/mysql/Makefile
@@ -4,12 +4,6 @@ SHELL := /bin/bash
 export IMAGE
 export GO111MODULE=on
 
-.PHONY: seed
-seed: export MYSQL_VERSION = 8.0.23
-seed:
-	make -C basic-seed run
-	make -C seed-with-many-rows run
-
 .PHONY: run
 run: 5.6.51 5.7.33 8.0.23
 
@@ -42,6 +36,7 @@ run: 5.6.51 5.7.33 8.0.23
 	make -C no-modify-charset run
 	make -C basic-seed run
 	make -C seed-with-many-rows run
+	make -C multiline-seed run
 
 .PHONY: 5.7.33
 5.7.33: export MYSQL_VERSION = 5.7.33
@@ -72,6 +67,7 @@ run: 5.6.51 5.7.33 8.0.23
 	make -C no-modify-charset run
 	make -C basic-seed run
 	make -C seed-with-many-rows run
+	make -C multiline-seed run
 
 .PHONY: 8.0.23
 8.0.23: export MYSQL_VERSION = 8.0.23
@@ -103,12 +99,7 @@ run: 5.6.51 5.7.33 8.0.23
 	make -C no-modify-charset run
 	make -C basic-seed run
 	make -C seed-with-many-rows run
-
-.PHONY: seed
-seed: export MYSQL_VERSION = 8.0.23
-seed:
-	make -C basic-seed run
-	make -C seed-with-many-rows run
+	make -C multiline-seed run
 
 .PHONY: build
 build: docker-build

--- a/integration/tests/mysql/multiline-seed/Dockerfile
+++ b/integration/tests/mysql/multiline-seed/Dockerfile
@@ -1,0 +1,9 @@
+FROM mysql:8.0
+
+ENV MYSQL_USER=schemahero
+ENV MYSQL_PASSWORD=password
+ENV MYSQL_DATABASE=schemahero
+ENV MYSQL_RANDOM_ROOT_PASSWORD=1
+
+## Insert fixtures
+COPY ./fixtures.sql /docker-entrypoint-initdb.d/

--- a/integration/tests/mysql/multiline-seed/Makefile
+++ b/integration/tests/mysql/multiline-seed/Makefile
@@ -1,0 +1,4 @@
+include ../common.mk
+
+TEST_NAME := mysql-multiline-seed
+SPEC_FILE := ./specs/users.yaml

--- a/integration/tests/mysql/multiline-seed/expect.sql
+++ b/integration/tests/mysql/multiline-seed/expect.sql
@@ -1,0 +1,2 @@
+create table `users` (`id` int (11), `login` varchar (255), `address` text, primary key (`id`));
+insert ignore into users (id, login, address) values (1, 'test', CONCAT_WS(CHAR(10 using utf8), '123 Main St', 'Los Angeles, CA 90015'));

--- a/integration/tests/mysql/multiline-seed/fixtures.sql
+++ b/integration/tests/mysql/multiline-seed/fixtures.sql
@@ -1,0 +1,5 @@
+create table other (
+  id integer primary key not null,
+  login varchar(255) not null,
+  address mediumtext
+);

--- a/integration/tests/mysql/multiline-seed/specs/users.yaml
+++ b/integration/tests/mysql/multiline-seed/specs/users.yaml
@@ -1,0 +1,27 @@
+database: schemahero
+name: users
+requires: []
+schema:
+  mysql:
+    primaryKey: [id]
+    columns:
+      - name: id
+        type: integer
+      - name: login
+        type: varchar(255)
+      - name: address
+        type: text (65535)
+seedData:
+  rows:
+    - columns:
+      - column: id
+        value:
+          int: 1
+      - column: login
+        value:
+          str: test
+      - column: address
+        value:
+          str: |-
+            123 Main St
+            Los Angeles, CA 90015

--- a/pkg/cli/schemaherokubectlcli/plan.go
+++ b/pkg/cli/schemaherokubectlcli/plan.go
@@ -114,7 +114,7 @@ func PlanCmd() *cobra.Command {
 			} else {
 				statements, err := db.PlanSyncFromFile(v.GetString("spec-file"), v.GetString("spec-type"))
 				if err != nil {
-					return err
+					return fmt.Errorf("plan sync from file %q: %w", v.GetString("spec-file"), err)
 				}
 
 				if f != nil {

--- a/pkg/database/mysql/create.go
+++ b/pkg/database/mysql/create.go
@@ -19,7 +19,18 @@ func SeedDataStatements(tableName string, seedData *schemasv1alpha4.SeedData) ([
 			if col.Value.Int != nil {
 				vals = append(vals, strconv.Itoa(*col.Value.Int))
 			} else if col.Value.Str != nil {
-				vals = append(vals, fmt.Sprintf("'%s'", *col.Value.Str))
+				// handle multiline strings
+				if strings.Contains(*col.Value.Str, "\n") {
+					builder := []string{
+						"CONCAT_WS(CHAR(10 using utf8)",
+					}
+					for _, s := range strings.Split(*col.Value.Str, "\n") {
+						builder = append(builder, fmt.Sprintf("'%s'", s))
+					}
+					vals = append(vals, fmt.Sprintf("%s)", strings.Join(builder, ", ")))
+				} else {
+					vals = append(vals, fmt.Sprintf("'%s'", *col.Value.Str))
+				}
 			}
 		}
 

--- a/pkg/installer/assets/schemas.schemahero.io_tables.yaml
+++ b/pkg/installer/assets/schemas.schemahero.io_tables.yaml
@@ -513,16 +513,28 @@ spec:
                   rows:
                     items:
                       properties:
-                        column:
-                          type: string
-                        value:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          x-kubernetes-int-or-string: true
+                        columns:
+                          items:
+                            properties:
+                              column:
+                                type: string
+                              value:
+                                properties:
+                                  int:
+                                    type: integer
+                                  str:
+                                    type: string
+                                required:
+                                - int
+                                - str
+                                type: object
+                            required:
+                            - column
+                            - value
+                            type: object
+                          type: array
                       required:
-                      - column
-                      - value
+                      - columns
                       type: object
                     type: array
                 required:


### PR DESCRIPTION
With this change:

given a spec:

```
database: schemahero
name: users
requires: []
schema:
  mysql:
    primaryKey: [id]
    columns:
      - name: id
        type: integer
      - name: login
        type: varchar(255)
      - name: address
        type: text (65535)
seedData:
  rows:
    - columns:
      - column: id
        value:
          int: 1
      - column: login
        value:
          str: test
      - column: address
        value:
          str: |-
            123 Main St
            Los Angeles, CA 90015
```

The output will be:

```
insert ignore into users (id, login, address) values (1, 'test', CONCAT_WS(CHAR(10 using utf8), '123 Main St', 'Los Angeles, CA 90015'));
```