### PR TITLE
Fix for multi column index

### DIFF
--- a/integration/tests/mysql/Makefile
+++ b/integration/tests/mysql/Makefile
@@ -37,6 +37,7 @@ run: 5.6.51 5.7.33 8.0.23
 	make -C basic-seed run
 	make -C seed-with-many-rows run
 	make -C multiline-seed run
+	make -C multi-column-index run
 
 .PHONY: 5.7.33
 5.7.33: export MYSQL_VERSION = 5.7.33
@@ -68,6 +69,7 @@ run: 5.6.51 5.7.33 8.0.23
 	make -C basic-seed run
 	make -C seed-with-many-rows run
 	make -C multiline-seed run
+	make -C multi-column-index run
 
 .PHONY: 8.0.23
 8.0.23: export MYSQL_VERSION = 8.0.23
@@ -100,6 +102,7 @@ run: 5.6.51 5.7.33 8.0.23
 	make -C basic-seed run
 	make -C seed-with-many-rows run
 	make -C multiline-seed run
+	make -C multi-column-index run
 
 .PHONY: build
 build: docker-build

--- a/integration/tests/mysql/multi-column-index/Dockerfile
+++ b/integration/tests/mysql/multi-column-index/Dockerfile
@@ -1,0 +1,9 @@
+FROM mysql:8.0
+
+ENV MYSQL_USER=schemahero
+ENV MYSQL_PASSWORD=password
+ENV MYSQL_DATABASE=schemahero
+ENV MYSQL_RANDOM_ROOT_PASSWORD=1
+
+## Insert fixtures
+COPY ./fixtures.sql /docker-entrypoint-initdb.d/

--- a/integration/tests/mysql/multi-column-index/Makefile
+++ b/integration/tests/mysql/multi-column-index/Makefile
@@ -1,0 +1,4 @@
+include ../common.mk
+
+TEST_NAME := mysql-multi-column-index
+SPEC_FILE := ./specs/table1.yaml

--- a/integration/tests/mysql/multi-column-index/fixtures.sql
+++ b/integration/tests/mysql/multi-column-index/fixtures.sql
@@ -1,0 +1,6 @@
+create table `table1` (
+  `teamid` char (64) not null,
+  `imageid` char (64) not null,
+  `v2_blobsum` varchar (255) null,
+  key idx_table1_imageid_teamid (imageid, teamid)
+) default character set latin1;

--- a/integration/tests/mysql/multi-column-index/specs/table1.yaml
+++ b/integration/tests/mysql/multi-column-index/specs/table1.yaml
@@ -1,0 +1,22 @@
+database: schemahero
+name: table1
+schema:
+  mysql:
+    defaultCharset: latin1
+    indexes:
+      - columns:
+          - imageid
+          - teamid
+    columns:
+    - name: teamid
+      type: char (64)
+      constraints:
+        notNull: true
+    - name: imageid
+      type: char (64)
+      constraints:
+        notNull: true
+    - name: v2_blobsum
+      type: varchar (255)
+      constraints:
+        notNull: false

--- a/pkg/database/mysql/deploy.go
+++ b/pkg/database/mysql/deploy.go
@@ -485,6 +485,11 @@ func buildRemoveIndexStatements(m *MysqlConnection, tableName string, mysqlTable
 	for _, currentIndex := range currentIndexes {
 		isMatch := false
 		for _, desiredIndex := range mysqlTableSchema.Indexes {
+			// if there's no name on the desired index,
+			// generate one
+			if desiredIndex.Name == "" {
+				desiredIndex.Name = types.GenerateMysqlIndexName(tableName, desiredIndex)
+			}
 			if currentIndex.Equals(types.MysqlSchemaIndexToIndex(desiredIndex)) {
 				isMatch = true
 			}


### PR DESCRIPTION
Fixes #637 

When creating mysql indexes, we generate a name if one is not specified in the schema. When this happens, the next time the table schema is applied, Schemahero thinks that the name has change (to "") and recreates the index. This results in an index drop and index add each iteration, which is terrible.

This change looks for empty index names and generates them in code to be used when comparing indexes that exist.

Also added a test to verify that this will work in the future.