### PR TITLE
Fix primary key query in mysql

### DIFF
--- a/integration/tests/mysql/Makefile
+++ b/integration/tests/mysql/Makefile
@@ -38,6 +38,7 @@ run: 5.6.51 5.7.33 8.0.23
 	make -C seed-with-many-rows run
 	make -C multiline-seed run
 	make -C multi-column-index run
+	make -C primary-key-keep run
 
 .PHONY: 5.7.33
 5.7.33: export MYSQL_VERSION = 5.7.33
@@ -70,6 +71,7 @@ run: 5.6.51 5.7.33 8.0.23
 	make -C seed-with-many-rows run
 	make -C multiline-seed run
 	make -C multi-column-index run
+	make -C primary-key-keep run
 
 .PHONY: 8.0.23
 8.0.23: export MYSQL_VERSION = 8.0.23
@@ -103,6 +105,7 @@ run: 5.6.51 5.7.33 8.0.23
 	make -C seed-with-many-rows run
 	make -C multiline-seed run
 	make -C multi-column-index run
+	make -C primary-key-keep run
 
 .PHONY: build
 build: docker-build

--- a/integration/tests/mysql/primary-key-keep/Dockerfile
+++ b/integration/tests/mysql/primary-key-keep/Dockerfile
@@ -1,0 +1,9 @@
+FROM mysql:8.0
+
+ENV MYSQL_USER=schemahero
+ENV MYSQL_PASSWORD=password
+ENV MYSQL_DATABASE=schemahero
+ENV MYSQL_RANDOM_ROOT_PASSWORD=1
+
+## Insert fixtures
+COPY ./fixtures.sql /docker-entrypoint-initdb.d/

--- a/integration/tests/mysql/primary-key-keep/Makefile
+++ b/integration/tests/mysql/primary-key-keep/Makefile
@@ -1,0 +1,4 @@
+include ../common.mk
+
+TEST_NAME := mysql-primary-key-keep
+SPEC_FILE := ./specs/table1.yaml

--- a/integration/tests/mysql/primary-key-keep/fixtures.sql
+++ b/integration/tests/mysql/primary-key-keep/fixtures.sql
@@ -1,0 +1,10 @@
+create table `table1` (
+  `manifest_id` varchar (255) not null,
+  `team_id` char (36) not null,
+  `namespace` varchar (255) not null,
+  `image_name` varchar (255) not null,
+  `image_tag` varchar (255) not null,
+  `signed_json` mediumtext not null,
+  `content_type` varchar (255) null,
+  primary key (`team_id`, `namespace`, `manifest_id`)
+) default character set latin1;

--- a/integration/tests/mysql/primary-key-keep/specs/table1.yaml
+++ b/integration/tests/mysql/primary-key-keep/specs/table1.yaml
@@ -1,0 +1,38 @@
+database: replicated
+name: table1
+schema:
+  mysql:
+    defaultCharset: latin1
+    primaryKey:
+    - team_id
+    - namespace
+    - manifest_id
+    columns:
+    - name: manifest_id
+      type: varchar (255)
+      constraints:
+        notNull: true
+    - name: team_id
+      type: char (36)
+      constraints:
+        notNull: true
+    - name: namespace
+      type: varchar (255)
+      constraints:
+        notNull: true
+    - name: image_name
+      type: varchar (255)
+      constraints:
+        notNull: true
+    - name: image_tag
+      type: varchar (255)
+      constraints:
+        notNull: true
+    - name: signed_json
+      type: mediumtext
+      constraints:
+        notNull: true
+    - name: content_type
+      type: varchar (255)
+      constraints:
+        notNull: false

--- a/pkg/database/mysql/deploy.go
+++ b/pkg/database/mysql/deploy.go
@@ -404,6 +404,7 @@ func buildAddPrimaryKeyStatements(m *MysqlConnection, tableName string, mysqlTab
 	if err != nil {
 		return nil, err
 	}
+
 	var mysqlTableSchemaPrimaryKey *types.KeyConstraint
 	if len(mysqlTableSchema.PrimaryKey) > 0 {
 		mysqlTableSchemaPrimaryKey = &types.KeyConstraint{

--- a/pkg/database/mysql/tables.go
+++ b/pkg/database/mysql/tables.go
@@ -18,7 +18,7 @@ func (m *MysqlConnection) ListTables() ([]*types.Table, error) {
 		return nil, errors.Wrap(err, "failed to select database default charset and collection")
 	}
 
-	query = `select 
+	query = `select
 t.table_name,
 t.TABLE_COLLATION,
 c.character_set_name FROM information_schema.TABLES t,
@@ -154,7 +154,7 @@ func (m *MysqlConnection) ListTableForeignKeys(databaseName string, tableName st
 }
 
 func (m *MysqlConnection) GetTablePrimaryKey(tableName string) (*types.KeyConstraint, error) {
-	query := `select distinct tc.CONSTRAINT_NAME, c.COLUMN_NAME, c.ORDINAL_POSITION
+	query := `select distinct tc.CONSTRAINT_NAME, c.COLUMN_NAME, kcu.ORDINAL_POSITION
 from information_schema.TABLE_CONSTRAINTS tc
 join information_schema.KEY_COLUMN_USAGE as kcu using (CONSTRAINT_SCHEMA, CONSTRAINT_NAME)
 join information_schema.COLUMNS as c on c.TABLE_SCHEMA = tc.CONSTRAINT_SCHEMA
@@ -162,7 +162,7 @@ join information_schema.COLUMNS as c on c.TABLE_SCHEMA = tc.CONSTRAINT_SCHEMA
   and kcu.TABLE_NAME = c.TABLE_NAME
   and kcu.COLUMN_NAME = c.COLUMN_NAME
 where tc.CONSTRAINT_TYPE = 'PRIMARY KEY' and tc.TABLE_NAME = ?
-order by c.ORDINAL_POSITION`
+order by kcu.ORDINAL_POSITION`
 
 	rows, err := m.db.Query(query, tableName)
 	if err != nil {
@@ -196,8 +196,8 @@ order by c.ORDINAL_POSITION`
 
 func (m *MysqlConnection) GetTableSchema(tableName string) ([]*types.Column, error) {
 	query := `select COLUMN_NAME, COLUMN_DEFAULT, IS_NULLABLE, EXTRA, DATA_TYPE, CHARACTER_MAXIMUM_LENGTH, NUMERIC_PRECISION, NUMERIC_SCALE
-from information_schema.COLUMNS 
-where TABLE_NAME = ? 
+from information_schema.COLUMNS
+where TABLE_NAME = ?
 order by ORDINAL_POSITION`
 	rows, err := m.db.Query(query, tableName)
 	if err != nil {

--- a/pkg/database/types/keyconstraint.go
+++ b/pkg/database/types/keyconstraint.go
@@ -24,6 +24,7 @@ func (k *KeyConstraint) Equals(other *KeyConstraint) bool {
 	if len(k.Columns) != len(other.Columns) {
 		return false
 	}
+
 	for i, column := range k.Columns {
 		if column != other.Columns[i] {
 			return false


### PR DESCRIPTION
Fixes #646 

We were previously selecting columns in a composite key and ordering them by the ordinal position in the table, not the ordinal position in the key. This was causing us to re-create keys because the key order didn't always match the column order. We never created them in the wrong order, but we did drop and recreate them each time.