### PR TITLE
Fix unecessary migration

### DIFF
--- a/integration/tests/mysql/Makefile
+++ b/integration/tests/mysql/Makefile
@@ -39,6 +39,7 @@ run: 5.6.51 5.7.33 8.0.23
 	make -C multiline-seed run
 	make -C multi-column-index run
 	make -C primary-key-keep run
+	make -C unchanged-charset run
 
 .PHONY: 5.7.33
 5.7.33: export MYSQL_VERSION = 5.7.33
@@ -72,6 +73,7 @@ run: 5.6.51 5.7.33 8.0.23
 	make -C multiline-seed run
 	make -C multi-column-index run
 	make -C primary-key-keep run
+	make -C unchanged-charset run
 
 .PHONY: 8.0.23
 8.0.23: export MYSQL_VERSION = 8.0.23
@@ -106,6 +108,7 @@ run: 5.6.51 5.7.33 8.0.23
 	make -C multiline-seed run
 	make -C multi-column-index run
 	make -C primary-key-keep run
+	make -C unchanged-charset run
 
 .PHONY: build
 build: docker-build

--- a/integration/tests/mysql/unchanged-charset/Dockerfile
+++ b/integration/tests/mysql/unchanged-charset/Dockerfile
@@ -1,0 +1,9 @@
+FROM mysql:8.0
+
+ENV MYSQL_USER=schemahero
+ENV MYSQL_PASSWORD=password
+ENV MYSQL_DATABASE=schemahero
+ENV MYSQL_RANDOM_ROOT_PASSWORD=1
+
+## Insert fixtures
+COPY ./fixtures.sql /docker-entrypoint-initdb.d/

--- a/integration/tests/mysql/unchanged-charset/Makefile
+++ b/integration/tests/mysql/unchanged-charset/Makefile
@@ -1,0 +1,4 @@
+include ../common.mk
+
+TEST_NAME := mysql-unchanged-charset
+SPEC_FILE := ./specs/table1.yaml

--- a/integration/tests/mysql/unchanged-charset/fixtures.sql
+++ b/integration/tests/mysql/unchanged-charset/fixtures.sql
@@ -1,0 +1,13 @@
+create table `table1` (
+  `channel_id` varchar (255) not null,
+  `created_at` datetime not null,
+  `updated_at` datetime null,
+  `version_label` varchar (255) null,
+  `release_notes` text character set utf8mb4 null,
+  `release_sequence` bigint (20) not null,
+  `channel_sequence` bigint (20) not null,
+  `airgap_locked_at` datetime null,
+  `force_airgap_build` tinyint (1) not null default '0',
+  primary key (`channel_id`, `channel_sequence`),
+  key idx_channel_id_release_sequence (channel_id, release_sequence)
+) default character set latin1;

--- a/integration/tests/mysql/unchanged-charset/specs/table1.yaml
+++ b/integration/tests/mysql/unchanged-charset/specs/table1.yaml
@@ -1,0 +1,52 @@
+database: replicated
+name: table1
+schema:
+  mysql:
+    defaultCharset: latin1
+    primaryKey:
+    - channel_id
+    - channel_sequence
+    indexes:
+    - columns:
+      - channel_id
+      - release_sequence
+      name: idx_channel_id_release_sequence
+    columns:
+    - name: channel_id
+      type: varchar (255)
+      constraints:
+        notNull: true
+    - name: created_at
+      type: datetime
+      constraints:
+        notNull: true
+    - name: updated_at
+      type: datetime
+      constraints:
+        notNull: false
+    - name: version_label
+      type: varchar (255)
+      constraints:
+        notNull: false
+    - name: release_notes
+      charset: utf8mb4
+      type: text (65535)
+      constraints:
+        notNull: false
+    - name: release_sequence
+      type: bigint (19, 0)
+      constraints:
+        notNull: true
+    - name: channel_sequence
+      type: bigint (19, 0)
+      constraints:
+        notNull: true
+    - name: airgap_locked_at
+      type: datetime
+      constraints:
+        notNull: false
+    - name: force_airgap_build
+      type: tinyint (3, 0)
+      constraints:
+        notNull: true
+      default: "0"

--- a/pkg/database/mysql/alter.go
+++ b/pkg/database/mysql/alter.go
@@ -26,6 +26,11 @@ func AlterColumnStatements(tableName string, primaryKeys []string, desiredColumn
 				ensureColumnConstraintsNotNullTrue(column)
 			}
 
+			// this is a pretty rough hack for now
+			if column.Collation == "" && existingColumn.Collation != "" {
+				column.Collation = existingColumn.Collation
+			}
+
 			if columnsMatch(*existingColumn, *column, defaultCharset, defaultCollation) {
 				return []string{}, nil
 			}


### PR DESCRIPTION
Signed-off-by: Marc Campbell <marc.e.campbell@gmail.com>

Fixes #654 

The ddl generation could use a refactor. This code is getting complex. We have the right state, but need to think more about how to turn it into a DDL statement that doesn't include uneccesary changes