### PR TITLE
Ability to ignore seed data

### DIFF
--- a/integration/tests/cassandra/common.mk
+++ b/integration/tests/cassandra/common.mk
@@ -14,7 +14,7 @@ run:
 	docker exec $(DATABASE_CONTAINER_NAME) cqlsh -k schemahero -f /fixtures.sql
 
 	# Plan
-	../../../../bin/kubectl-schemahero plan --keyspace schemahero --host 127.0.0.1:9042 --driver=$(DRIVER) --spec-type $(SPEC_TYPE) --spec-file $(SPEC_FILE) > out.sql
+	../../../../bin/kubectl-schemahero plan --seed-data --keyspace schemahero --host 127.0.0.1:9042 --driver=$(DRIVER) --spec-type $(SPEC_TYPE) --spec-file $(SPEC_FILE) > out.sql
 
 	# Verify
 	@echo Verifying results for $(TEST_NAME)

--- a/integration/tests/cockroach/common.mk
+++ b/integration/tests/cockroach/common.mk
@@ -18,7 +18,7 @@ run:
 	while ! docker exec -it $(DATABASE_CONTAINER_NAME) /cockroach/cockroach sql --insecure --execute "SELECT 1;"; do sleep 1; done
 
 	# Plan
-	../../../../bin/kubectl-schemahero plan --driver=$(DRIVER) --uri="$(URI)" --spec-file $(SPEC_FILE) > out.sql
+	../../../../bin/kubectl-schemahero plan --seed-data --driver=$(DRIVER) --uri="$(URI)" --spec-file $(SPEC_FILE) > out.sql
 
 	# Verify
 	@echo Verifying results for $(TEST_NAME)

--- a/integration/tests/mysql/common.mk
+++ b/integration/tests/mysql/common.mk
@@ -14,7 +14,7 @@ run:
 	@sleep 10
 
 	# Plan
-	../../../../bin/kubectl-schemahero plan --driver=$(DRIVER) --uri="$(URI)" --spec-file $(SPEC_FILE) > out.sql
+	../../../../bin/kubectl-schemahero plan --seed-data --driver=$(DRIVER) --uri="$(URI)" --spec-file $(SPEC_FILE) > out.sql
 
 	# Verify
 	@echo Verifying results for $(TEST_NAME)

--- a/integration/tests/postgres/common.mk
+++ b/integration/tests/postgres/common.mk
@@ -17,7 +17,7 @@ run:
 	@sleep 1
 
 	# Plan
-	../../../../bin/kubectl-schemahero plan --driver=$(DRIVER) --uri="$(URI)" --spec-file $(SPEC_FILE) > out.sql
+	../../../../bin/kubectl-schemahero plan --seed-data --driver=$(DRIVER) --uri="$(URI)" --spec-file $(SPEC_FILE) > out.sql
 
 	# Verify
 	@echo Verifying results for $(TEST_NAME)

--- a/integration/tests/sqlite/common.mk
+++ b/integration/tests/sqlite/common.mk
@@ -17,7 +17,7 @@ run:
 	docker run --rm -v `pwd`/db:/db -v `pwd`/fixtures.sql:/fixtures.sql --name $(DATABASE_CONTAINER_NAME) keinos/sqlite3:latest sqlite3 /db/db.db ".read /fixtures.sql"
 
 	# Plan
-	../../../../bin/kubectl-schemahero plan --driver=$(DRIVER) --uri="$(URI)" --spec-file $(SPEC_FILE) > out.sql
+	../../../../bin/kubectl-schemahero plan --seed-data --driver=$(DRIVER) --uri="$(URI)" --spec-file $(SPEC_FILE) > out.sql
 
 	# Verify
 	@echo Verifying results for $(TEST_NAME)

--- a/pkg/apis/databases/v1alpha4/database_types.go
+++ b/pkg/apis/databases/v1alpha4/database_types.go
@@ -40,6 +40,7 @@ type DatabaseSpec struct {
 
 	//+kubebuilder:default:=false
 	ImmediateDeploy bool              `json:"immediateDeploy,omitempty"`
+	DeploySeedData  bool              `json:"deploySeedData,omitempty"` // TODO remove this for envs in 0.13.0
 	SchemaHero      *SchemaHero       `json:"schemahero,omitempty"`
 	Template        *DatabaseTemplate `json:"template,omitempty"`
 }

--- a/pkg/cli/schemaherokubectlcli/plan.go
+++ b/pkg/cli/schemaherokubectlcli/plan.go
@@ -77,14 +77,15 @@ func PlanCmd() *cobra.Command {
 			}
 
 			db := database.Database{
-				InputDir:  v.GetString("input-dir"),
-				OutputDir: v.GetString("output-dir"),
-				Driver:    v.GetString("driver"),
-				URI:       v.GetString("uri"),
-				Hosts:     v.GetStringSlice("host"),
-				Username:  v.GetString("username"),
-				Password:  v.GetString("password"),
-				Keyspace:  v.GetString("keyspace"),
+				InputDir:       v.GetString("input-dir"),
+				OutputDir:      v.GetString("output-dir"),
+				Driver:         v.GetString("driver"),
+				URI:            v.GetString("uri"),
+				Hosts:          v.GetStringSlice("host"),
+				Username:       v.GetString("username"),
+				Password:       v.GetString("password"),
+				Keyspace:       v.GetString("keyspace"),
+				DeploySeedData: v.GetBool("seed-data"),
 			}
 
 			if fi.Mode().IsDir() {
@@ -163,5 +164,6 @@ func PlanCmd() *cobra.Command {
 	cmd.Flags().String("out", "", "filename to write DDL statements to, if not present output file be written to stdout")
 	cmd.Flags().Bool("overwrite", true, "when set, will overwrite the out file, if it already exists")
 
+	cmd.Flags().Bool("seed-data", false, "when set, will deploy seed data")
 	return cmd
 }

--- a/pkg/controller/table/reconile_table.go
+++ b/pkg/controller/table/reconile_table.go
@@ -162,8 +162,9 @@ func (r *ReconcileTable) plan(ctx context.Context, databaseInstance *databasesv1
 	}
 
 	db := database.Database{
-		Driver: driver,
-		URI:    connectionURI,
+		Driver:         driver,
+		URI:            connectionURI,
+		DeploySeedData: databaseInstance.Spec.DeploySeedData,
 	}
 
 	// plan the schema

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -19,14 +19,15 @@ import (
 )
 
 type Database struct {
-	InputDir  string
-	OutputDir string
-	Driver    string
-	URI       string
-	Hosts     []string
-	Username  string
-	Password  string
-	Keyspace  string
+	InputDir       string
+	OutputDir      string
+	Driver         string
+	URI            string
+	Hosts          []string
+	Username       string
+	Password       string
+	Keyspace       string
+	DeploySeedData bool
 }
 
 func (d *Database) CreateFixturesSync() error {
@@ -173,16 +174,21 @@ func (d *Database) PlanSyncTableSpec(spec *schemasv1alpha4.TableSpec) ([]string,
 		return []string{}, nil
 	}
 
+	var seedData *schemasv1alpha4.SeedData
+	if d.DeploySeedData {
+		seedData = spec.SeedData
+	}
+
 	if d.Driver == "postgres" {
-		return postgres.PlanPostgresTable(d.URI, spec.Name, spec.Schema.Postgres, spec.SeedData)
+		return postgres.PlanPostgresTable(d.URI, spec.Name, spec.Schema.Postgres, seedData)
 	} else if d.Driver == "mysql" {
-		return mysql.PlanMysqlTable(d.URI, spec.Name, spec.Schema.Mysql, spec.SeedData)
+		return mysql.PlanMysqlTable(d.URI, spec.Name, spec.Schema.Mysql, seedData)
 	} else if d.Driver == "cockroachdb" {
-		return postgres.PlanPostgresTable(d.URI, spec.Name, spec.Schema.CockroachDB, spec.SeedData)
+		return postgres.PlanPostgresTable(d.URI, spec.Name, spec.Schema.CockroachDB, seedData)
 	} else if d.Driver == "cassandra" {
-		return cassandra.PlanCassandraTable(d.Hosts, d.Username, d.Password, d.Keyspace, spec.Name, spec.Schema.Cassandra, spec.SeedData)
+		return cassandra.PlanCassandraTable(d.Hosts, d.Username, d.Password, d.Keyspace, spec.Name, spec.Schema.Cassandra, seedData)
 	} else if d.Driver == "sqlite" {
-		return sqlite.PlanSqliteTable(d.URI, spec.Name, spec.Schema.SQLite, spec.SeedData)
+		return sqlite.PlanSqliteTable(d.URI, spec.Name, spec.Schema.SQLite, seedData)
 	}
 
 	return nil, errors.Errorf("unknown database driver: %q", d.Driver)


### PR DESCRIPTION
Signed-off-by: Marc Campbell <marc.e.campbell@gmail.com>

This is a temporary change until we have envs in.
The problem is that seedData is useful in some environments and not in others. I don't want seed data in my production env, but I do in dev.
I set the field up this way so that it defaults to false, allowing an easier migration to 0.13.0 alpha releases.