### PR TITLE
fix: add missing postgresql secret data

### DIFF
--- a/examples/tutorial/postgresql/postgresql-11.8.0.yaml
+++ b/examples/tutorial/postgresql/postgresql-11.8.0.yaml
@@ -10,6 +10,7 @@ metadata:
     chart: postgresql-8.10.0
 type: Opaque
 data:
+  postgresql-password: "cGFzc3dvcmQ="
   uri: cG9zdGdyZXNxbDovL2FpcmxpbmVkYi11c2VyOnBhc3N3b3JkQHBvc3RncmVzcWw6NTQzMi9wb3N0Z3Jlcw==
 ---
 # Source: postgresql/templates/svc-headless.yaml
@@ -102,7 +103,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: postgresql
-                  key: postgresql-postgres-password
+                  key: postgresql-password
             - name: POSTGRES_USER
               value: "airlinedb-user"
             - name: POSTGRES_PASSWORD


### PR DESCRIPTION
**Issue:** Statefulset expects  `postgresql` Secret to have data for `postgresql-postgres-password` and `postgresql-password`.
Without these secret data statefulset fails to deploy. 

**Fix:** add missing `postgres` Secret data

https://github.com/schemahero/schemahero/blob/230b52e32982e711b37c0802b85dbfb762e20a35/examples/tutorial/postgresql/postgresql-11.8.0.yaml#L101-L112

console logs:

```
➜   k get po -n schemahero-tutorial
NAME           READY   STATUS                       RESTARTS   AGE
postgresql-0   0/1     CreateContainerConfigError   0          11s

➜  k describe po -n schemahero-tutorial postgresql-0
Name:         postgresql-0
Namespace:    schemahero-tutorial
Priority:     0
Node:         kind-control-plane/172.1
...
...
...
Events:
  Type     Reason     Age               From               Message
  ----     ------     ----              ----               -------
  Normal   Scheduled  20s               default-scheduler  Successfully assigned schemahero-tutorial/postgresql-0 to kind-control-plane
  Normal   Pulled     4s (x3 over 20s)  kubelet            Container image "docker.io/bitnami/postgresql:11.8.0-debian-10-r5" already present on machine
  Warning  Failed     4s (x3 over 20s)  kubelet            Error: couldn't find key postgresql-postgres-password in Secret schemahero-tutorial/postgresql
```