### PR TITLE
Improve schemahero logging

### DIFF
--- a/pkg/cli/managercli/run.go
+++ b/pkg/cli/managercli/run.go
@@ -34,7 +34,9 @@ func RunCmd() *cobra.Command {
 
 			v := viper.GetViper()
 
+			isDebug := false
 			if v.GetString("log-level") == "debug" {
+				isDebug = true
 				logger.SetDebug()
 			}
 
@@ -68,7 +70,7 @@ func RunCmd() *cobra.Command {
 
 			if v.GetBool("enable-database-controller") {
 				logger.Info("Starting database controller")
-				if err := databasecontroller.Add(mgr, v.GetString("manager-image"), v.GetString("manager-tag")); err != nil {
+				if err := databasecontroller.Add(mgr, v.GetString("manager-image"), v.GetString("manager-tag"), isDebug); err != nil {
 					logger.Error(err)
 					os.Exit(1)
 				}

--- a/pkg/cli/managercli/run.go
+++ b/pkg/cli/managercli/run.go
@@ -67,6 +67,7 @@ func RunCmd() *cobra.Command {
 			}
 
 			if v.GetBool("enable-database-controller") {
+				logger.Info("Starting database controller")
 				if err := databasecontroller.Add(mgr, v.GetString("manager-image"), v.GetString("manager-tag")); err != nil {
 					logger.Error(err)
 					os.Exit(1)
@@ -74,6 +75,7 @@ func RunCmd() *cobra.Command {
 			}
 
 			if len(v.GetStringSlice("database-name")) > 0 {
+				logger.Infof("Starting controllers for %+v", v.GetStringSlice("database-name"))
 				if err := databasecontroller.AddForDatabaseSchemasOnly(mgr, v.GetStringSlice("database-name")); err != nil {
 					logger.Error(err)
 					os.Exit(1)

--- a/pkg/controller/database/database_controller.go
+++ b/pkg/controller/database/database_controller.go
@@ -44,6 +44,7 @@ type ReconcileDatabase struct {
 	scheme       *runtime.Scheme
 	managerImage string
 	managerTag   string
+	debugLogs    bool
 }
 
 // Reconcile reads that state of the cluster for a Database object and makes changes based on the state read
@@ -164,6 +165,10 @@ func (r *ReconcileDatabase) Reconcile(ctx context.Context, request reconcile.Req
 				},
 			},
 		},
+	}
+
+	if r.debugLogs {
+		desiredStatefulSet.Spec.Template.Spec.Containers[0].Args = append(desiredStatefulSet.Spec.Template.Spec.Containers[0].Args, "--log-level", "debug")
 	}
 
 	existingStatefulset := appsv1.StatefulSet{}

--- a/pkg/controller/database/database_controller_test.go
+++ b/pkg/controller/database/database_controller_test.go
@@ -61,7 +61,7 @@ func TestDbControllerTest(t *testing.T) {
 	}
 
 	// add the Controller to the Manager
-	err = Add(mgr, "", "")
+	err = Add(mgr, "", "", true)
 	if err != nil {
 		t.Fatalf("Failed to add controller to manager: %v", err)
 	}

--- a/pkg/controller/database/setup.go
+++ b/pkg/controller/database/setup.go
@@ -30,8 +30,8 @@ var tenSeconds = int64(10)
 
 // Add creates a new Database Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func Add(mgr manager.Manager, managerImage string, managerTag string) error {
-	return add(mgr, newReconciler(mgr, managerImage, managerTag), "databaseController")
+func Add(mgr manager.Manager, managerImage string, managerTag string, debugLogs bool) error {
+	return add(mgr, newReconciler(mgr, managerImage, managerTag, debugLogs), "databaseController")
 }
 
 // AddForDatabaseSchemasOnly creates a new Database Controller to watch for changes to a specific database object. This is how database-level schema
@@ -41,12 +41,13 @@ func AddForDatabaseSchemasOnly(mgr manager.Manager, databaseNames []string) erro
 }
 
 // newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager, managerImage string, managerTag string) reconcile.Reconciler {
+func newReconciler(mgr manager.Manager, managerImage string, managerTag string, debugLogs bool) reconcile.Reconciler {
 	return &ReconcileDatabase{
 		Client:       mgr.GetClient(),
 		scheme:       mgr.GetScheme(),
 		managerImage: managerImage,
 		managerTag:   managerTag,
+		debugLogs:    debugLogs,
 	}
 }
 


### PR DESCRIPTION
We should better describe what a particular pod is doing upon startup, and pass --log-level=debug through to db managers