### PR TITLE
Fix for the serial and bigserial types in postgres

### DIFF
--- a/pkg/database/postgres/alter.go
+++ b/pkg/database/postgres/alter.go
@@ -76,12 +76,7 @@ func AlterColumnStatements(tableName string, primaryKeys []string, desiredColumn
 			}
 
 			changes := []string{}
-
-			// Checking if the column is type 'serial'
-			if column.DataType == "serial" &&
-				existingColumn.DataType == "integer" && // when a column is declared serial, the actual datatype becomes integer
-				strings.Contains(*existingColumn.ColumnDefault, tableName+"_"+existingColumn.Name+"_seq") { // and a new sequance is created to handle the increment
-
+			if column.DataType != "serial" && column.DataType != "bigserial" {
 				if existingColumn.DataType != column.DataType {
 					changes = append(changes, fmt.Sprintf("%s type %s", alterStatement, column.DataType))
 				} else if column.DataType == existingColumn.DataType {

--- a/pkg/database/postgres/alter_test.go
+++ b/pkg/database/postgres/alter_test.go
@@ -106,6 +106,26 @@ func Test_AlterColumnStatments(t *testing.T) {
 			expectedStatements: []string{`alter table "t" alter column "b" type integer`},
 		},
 		{
+			name:      "ignore serial type",
+			tableName: "t",
+			desiredColumns: []*schemasv1alpha4.PostgresqlTableColumn{
+				{
+					Name: "a",
+					Type: "serial",
+				},
+				{
+					Name: "b",
+					Type: "integer",
+				},
+			},
+			existingColumn: &types.Column{
+				Name:          "a",
+				DataType:      "integer",
+				ColumnDefault: nil,
+			},
+			expectedStatements: []string{},
+		},
+		{
 			name:      "drop column",
 			tableName: "t",
 			desiredColumns: []*schemasv1alpha4.PostgresqlTableColumn{


### PR DESCRIPTION
HI,
i modified the code to fix #713 
I'm not an expert in go, so sorry if the code is not up to standards.

The idea behind the fix is that serial and bigserial are not types and so no alter should be triggered if the table types do not match.
The other thing is the serial types create a column integer with a sequence attached, so no table can contain a column type serial.