### PR TITLE
Fix for the serial and bigserial types in postgres

### DIFF
--- a/pkg/database/postgres/alter.go
+++ b/pkg/database/postgres/alter.go
@@ -76,35 +76,37 @@ func AlterColumnStatements(tableName string, primaryKeys []string, desiredColumn
 			}
 
 			changes := []string{}
-			if existingColumn.DataType != column.DataType {
-				changes = append(changes, fmt.Sprintf("%s type %s", alterStatement, column.DataType))
-			} else if column.DataType == existingColumn.DataType {
-				if column.IsArray != existingColumn.IsArray {
-					changes = append(changes, fmt.Sprintf("%s type %s[] using %s::%s[]", alterStatement, column.DataType, pgx.Identifier{existingColumn.Name}.Sanitize(), column.DataType))
-				}
-			}
-
-			if column.ColumnDefault != nil {
-				if existingColumn.ColumnDefault == nil || *column.ColumnDefault != *existingColumn.ColumnDefault {
-					changes = append(changes, fmt.Sprintf("%s set default '%s'", alterStatement, *column.ColumnDefault))
-				}
-			} else if existingColumn.ColumnDefault != nil {
-				changes = append(changes, fmt.Sprintf("%s drop default", alterStatement))
-			}
-
-			// too much complexity below!
-			if column.Constraints != nil || existingColumn.Constraints != nil {
-				isPrimaryKey := false
-				for _, primaryKey := range primaryKeys {
-					if column.Name == primaryKey {
-						isPrimaryKey = true
+			if column.DataType != "serial" && column.DataType != "bigserial" {
+				if existingColumn.DataType != column.DataType {
+					changes = append(changes, fmt.Sprintf("%s type %s", alterStatement, column.DataType))
+				} else if column.DataType == existingColumn.DataType {
+					if column.IsArray != existingColumn.IsArray {
+						changes = append(changes, fmt.Sprintf("%s type %s[] using %s::%s[]", alterStatement, column.DataType, pgx.Identifier{existingColumn.Name}.Sanitize(), column.DataType))
 					}
 				}
 
-				if !isPrimaryKey {
-					if existingColumn.Constraints != nil && existingColumn.Constraints.NotNull != nil && *existingColumn.Constraints.NotNull {
-						if column.Constraints == nil || column.Constraints.NotNull == nil || !*column.Constraints.NotNull {
-							changes = append(changes, fmt.Sprintf("%s drop not null", alterStatement))
+				if column.ColumnDefault != nil {
+					if existingColumn.ColumnDefault == nil || *column.ColumnDefault != *existingColumn.ColumnDefault {
+						changes = append(changes, fmt.Sprintf("%s set default '%s'", alterStatement, *column.ColumnDefault))
+					}
+				} else if existingColumn.ColumnDefault != nil {
+					changes = append(changes, fmt.Sprintf("%s drop default", alterStatement))
+				}
+
+				// too much complexity below!
+				if column.Constraints != nil || existingColumn.Constraints != nil {
+					isPrimaryKey := false
+					for _, primaryKey := range primaryKeys {
+						if column.Name == primaryKey {
+							isPrimaryKey = true
+						}
+					}
+
+					if !isPrimaryKey {
+						if existingColumn.Constraints != nil && existingColumn.Constraints.NotNull != nil && *existingColumn.Constraints.NotNull {
+							if column.Constraints == nil || column.Constraints.NotNull == nil || !*column.Constraints.NotNull {
+								changes = append(changes, fmt.Sprintf("%s drop not null", alterStatement))
+							}
 						}
 					}
 				}

--- a/pkg/database/postgres/alter_test.go
+++ b/pkg/database/postgres/alter_test.go
@@ -106,6 +106,26 @@ func Test_AlterColumnStatments(t *testing.T) {
 			expectedStatements: []string{`alter table "t" alter column "b" type integer`},
 		},
 		{
+			name:      "ignore serial",
+			tableName: "t",
+			desiredColumns: []*schemasv1alpha4.PostgresqlTableColumn{
+				{
+					Name: "a",
+					Type: "serial",
+				},
+				{
+					Name: "b",
+					Type: "integer",
+				},
+			},
+			existingColumn: &types.Column{
+				Name:          "a",
+				DataType:      "integer",
+				ColumnDefault: nil,
+			},
+			expectedStatements: []string{},
+		},
+		{
 			name:      "drop column",
 			tableName: "t",
 			desiredColumns: []*schemasv1alpha4.PostgresqlTableColumn{


### PR DESCRIPTION
HI,
let's hope that the third time's the charm 😄 
I modified the code for the issue #713 
I'm not an expert in go, so sorry if the code is not up to standards.

The idea behind the fix is that serial and bigserial are not types and so no alter should be triggered if the table types do not match.
The other thing is the serial types create a column integer with a sequence attached, so no table can contain a column type serial.