### PR TITLE
[fix] generate for postgres delivers empty colums result

### DIFF
--- a/pkg/database/postgres/tables.go
+++ b/pkg/database/postgres/tables.go
@@ -213,7 +213,7 @@ order by c.ordinal_position`
 }
 
 func (p *PostgresConnection) GetTableSchema(tableName string) ([]*types.Column, error) {
-	query := "select column_name, data_type, character_maximum_length, column_default, is_nullable from information_schema.columns where table_name = $1 and table_schema = $2"
+	query := "select column_name, data_type, character_maximum_length, column_default, is_nullable from information_schema.columns where table_name = $1 and table_catalog = $2"
 
 	rows, err := p.conn.Query(context.Background(), query, tableName, p.databaseName)
 	if err != nil {


### PR DESCRIPTION
Generate for postgres delivered result with no columns for any table. Query was using database-name instead of schema. Though hardcoding the schema is also dirty, it's already used like this in the file and should most probably be tackled in a different pr.