### PR TITLE
Support for fractional seconds precision in datetime and timestamp types for MySQL

### DIFF
--- a/integration/tests/timescaledb/column-set-default/expect.sql
+++ b/integration/tests/timescaledb/column-set-default/expect.sql
@@ -1,2 +1,2 @@
-alter table "users" alter column "num_seats" set default '5';
 alter table "users" alter column "account_type" set default 'trial';
+alter table "users" alter column "num_seats" set default '5';

--- a/integration/tests/timescaledb/column-unset-default/expect.sql
+++ b/integration/tests/timescaledb/column-unset-default/expect.sql
@@ -1,2 +1,2 @@
-alter table "users" alter column "num_seats" drop default, alter column "num_seats" drop not null;
 alter table "users" alter column "account_type" drop default, alter column "account_type" drop not null;
+alter table "users" alter column "num_seats" drop default, alter column "num_seats" drop not null;

--- a/pkg/database/mysql/parameterized.go
+++ b/pkg/database/mysql/parameterized.go
@@ -67,6 +67,40 @@ func maybeParseParameterizedColumnType(requestedType string) (string, error) {
 			}
 			columnType = fmt.Sprintf("char (%d)", max)
 		}
+	} else if strings.HasPrefix(requestedType, "datetime") {
+		r := regexp.MustCompile(`datetime\s*\((?P<max>\d*)\)`)
+
+		matchGroups := r.FindStringSubmatch(requestedType)
+		if len(matchGroups) == 0 {
+			return "", fmt.Errorf("invalid datetime precision")
+		} else {
+			maxStr := matchGroups[1]
+			max, err := strconv.Atoi(maxStr)
+			if err != nil {
+				return "", err
+			}
+			if max < 0 || max > 6 {
+				return "", fmt.Errorf("invalid datetime precision %d", max)
+			}
+			columnType = fmt.Sprintf("datetime (%d)", max)
+		}
+	} else if strings.HasPrefix(requestedType, "timestamp") {
+		r := regexp.MustCompile(`timestamp\s*\((?P<max>\d*)\)`)
+
+		matchGroups := r.FindStringSubmatch(requestedType)
+		if len(matchGroups) == 0 {
+			return "", fmt.Errorf("invalid timestamp precision")
+		} else {
+			maxStr := matchGroups[1]
+			max, err := strconv.Atoi(maxStr)
+			if err != nil {
+				return "", err
+			}
+			if max < 0 || max > 6 {
+				return "", fmt.Errorf("invalid timestamp precision %d", max)
+			}
+			columnType = fmt.Sprintf("timestamp (%d)", max)
+		}
 	} else if strings.HasPrefix(requestedType, "tinyint") {
 		r := regexp.MustCompile(`tinyint\s*\((?P<max>\d*)\)`)
 


### PR DESCRIPTION
Fixes #864