### PR TITLE
Fix image ref format on tagged builds

### DIFF
--- a/.github/workflows/tagged-release.yaml
+++ b/.github/workflows/tagged-release.yaml
@@ -184,7 +184,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            ${{ env.REGISTRY}}/${{ env.IMAGE_NAME }}
+            ${{ env.REGISTRY}}/${{ env.IMAGE_SCHEMAHERO_MANAGER_NAME }}
           flavor: |
             latest=false
           tags: |
@@ -238,7 +238,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            ${{ env.REGISTRY}}/${{ env.IMAGE_NAME }}
+            ${{ env.REGISTRY}}/${{ env.IMAGE_SCHEMAHERO_NAME }}
           flavor: |
             latest=false
           tags: |


### PR DESCRIPTION
Fixes

```
Error: buildx failed with: ERROR: invalid tag "schemahero/:0.14.0-alpha.4": invalid reference format
```

which happens because `env.IMAGE_NAME` is undefined and becomes an empty string.