### PR TITLE
fix: Update docker image meta data

### DIFF
--- a/.github/workflows/tagged-release.yaml
+++ b/.github/workflows/tagged-release.yaml
@@ -27,10 +27,6 @@ jobs:
         with:
           path: ${{ steps.go-cache-paths.outputs.go-build }}
           key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
-      - uses: actions/cache@v2
-        with:
-          path: ${{ steps.go-cache-paths.outputs.go-mod }}
-          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
 
       - run: make fmt
       - run: go mod tidy
@@ -184,7 +180,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            ${{ env.REGISTRY}}/${{ env.IMAGE_NAME }}
+            ${{ env.REGISTRY}}/${{ env.IMAGE_SCHEMAHERO_MANAGER_NAME }}
           flavor: |
             latest=false
           tags: |
@@ -238,7 +234,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            ${{ env.REGISTRY}}/${{ env.IMAGE_NAME }}
+            ${{ env.REGISTRY}}/${{ env.IMAGE_SCHEMAHERO_NAME }}
           flavor: |
             latest=false
           tags: |
@@ -353,6 +349,7 @@ jobs:
           DIGEST_SCHEMAHERO_MANAGER: ${{ needs.build-docker-manager.outputs.digest }}
 
   krew:
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'alpha') && !contains(github.ref, 'beta')
     runs-on: ubuntu-latest
     needs:
       - github-release-tarballs


### PR DESCRIPTION
- remove duplicate cache@v2 in build job
- update krew job to skip it instead of showing it as failing in github actions

Signed-off-by: Ales Verbic <averbic@applause.com>