### PR TITLE
feat: remove node affinity architecture constraints

### DIFF
--- a/pkg/controller/database/database_controller.go
+++ b/pkg/controller/database/database_controller.go
@@ -126,13 +126,6 @@ func (r *ReconcileDatabase) Reconcile(ctx context.Context, request reconcile.Req
 													"linux",
 												},
 											},
-											{
-												Key:      "kubernetes.io/arch",
-												Operator: corev1.NodeSelectorOpIn,
-												Values: []string{
-													"amd64",
-												},
-											},
 										},
 									},
 								},

--- a/pkg/installer/manager.go
+++ b/pkg/installer/manager.go
@@ -247,13 +247,6 @@ func manager(namespace string) *appsv1.StatefulSet {
 													"linux",
 												},
 											},
-											{
-												Key:      "kubernetes.io/arch",
-												Operator: corev1.NodeSelectorOpIn,
-												Values: []string{
-													"amd64",
-												},
-											},
 										},
 									},
 								},


### PR DESCRIPTION
Schemahero images are now built for both amd64 and arm64 so node affinity should no longer be required.

This implements #906 