### PR TITLE
replace io/ioutil package with io and os package

### DIFF
--- a/pkg/apis/databases/v1alpha4/vault_connection.go
+++ b/pkg/apis/databases/v1alpha4/vault_connection.go
@@ -21,8 +21,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
 	"text/template"
 
 	"github.com/pkg/errors"
@@ -34,7 +35,7 @@ import (
 func (d *Database) getVaultConnection(ctx context.Context, clientset kubernetes.Interface, driver string, valueOrValueFrom ValueOrValueFrom) (string, string, error) {
 	// if the value is in vault and we are using the vault injector, just read the file
 	if valueOrValueFrom.ValueFrom.Vault.AgentInject {
-		vaultInjectedFileContents, err := ioutil.ReadFile("/vault/secrets/schemaherouri")
+		vaultInjectedFileContents, err := os.ReadFile("/vault/secrets/schemaherouri")
 		if err != nil {
 			return "", "", errors.Wrap(err, "failed to read vault injected file")
 		}
@@ -102,7 +103,7 @@ func (d *Database) getVaultConnection(ctx context.Context, clientset kubernetes.
 		Auth: LoginResponseAuth{},
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", "", errors.Wrap(err, "failed to read response body")
 	}
@@ -133,7 +134,7 @@ func (d *Database) getVaultConnection(ctx context.Context, clientset kubernetes.
 		Data: map[string]interface{}{},
 	}
 
-	b, err = ioutil.ReadAll(resp.Body)
+	b, err = io.ReadAll(resp.Body)
 	if err != nil {
 		return "", "", errors.Wrap(err, "failed to read body")
 	}
@@ -197,7 +198,7 @@ func getConnectionURITemplate(vault *Vault, token string, dbName string) (string
 			Data: ConfigDataResponse{},
 		}
 
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return "", errors.Wrap(err, "failed to read body")
 		}

--- a/pkg/cli/schemaherokubectlcli/apply.go
+++ b/pkg/cli/schemaherokubectlcli/apply.go
@@ -2,7 +2,6 @@ package schemaherokubectlcli
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -75,7 +74,7 @@ func ApplyCmd() *cobra.Command {
 						return nil
 					}
 
-					ddl, err := ioutil.ReadFile(filepath.Clean(path))
+					ddl, err := os.ReadFile(filepath.Clean(path))
 					if err != nil {
 						return errors.Wrap(err, "failed to read file in directory")
 					}
@@ -92,7 +91,7 @@ func ApplyCmd() *cobra.Command {
 
 				return nil
 			} else {
-				ddl, err := ioutil.ReadFile(v.GetString("ddl"))
+				ddl, err := os.ReadFile(v.GetString("ddl"))
 				if err != nil {
 					return errors.Wrap(err, "failed to read file")
 				}

--- a/pkg/cli/schemaherokubectlcli/install.go
+++ b/pkg/cli/schemaherokubectlcli/install.go
@@ -3,7 +3,6 @@ package schemaherokubectlcli
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -43,7 +42,7 @@ For more control, use the --yaml flag to avoid making any changes to the cluster
 					}
 
 					for filename, manifest := range manifests {
-						if err := ioutil.WriteFile(filepath.Join(v.GetString("out-dir"), filename), manifest, 0600); err != nil {
+						if err := os.WriteFile(filepath.Join(v.GetString("out-dir"), filename), manifest, 0600); err != nil {
 							fmt.Printf("Error: %s\n", err.Error())
 							return err
 						}

--- a/pkg/cli/schemaherokubectlcli/plan.go
+++ b/pkg/cli/schemaherokubectlcli/plan.go
@@ -2,7 +2,6 @@ package schemaherokubectlcli
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -109,7 +108,7 @@ func PlanCmd() *cobra.Command {
 						return nil
 					}
 
-					specContents, err := ioutil.ReadFile(filepath.Clean(path))
+					specContents, err := os.ReadFile(filepath.Clean(path))
 					if err != nil {
 						return errors.Wrap(err, "failed to read file")
 					}

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -2,7 +2,6 @@ package database
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -49,7 +48,7 @@ func (d *Database) CreateFixturesSync() error {
 			return nil
 		}
 
-		fileData, err := ioutil.ReadFile(filepath.Join(d.InputDir, info.Name()))
+		fileData, err := os.ReadFile(filepath.Join(d.InputDir, info.Name()))
 		if err != nil {
 			return err
 		}
@@ -164,7 +163,7 @@ func (d *Database) CreateFixturesSync() error {
 		os.MkdirAll(d.OutputDir, 0750)
 	}
 
-	err = ioutil.WriteFile(filepath.Join(d.OutputDir, "fixtures.sql"), []byte(output), 0600)
+	err = os.WriteFile(filepath.Join(d.OutputDir, "fixtures.sql"), []byte(output), 0600)
 	if err != nil {
 		return err
 	}
@@ -173,7 +172,7 @@ func (d *Database) CreateFixturesSync() error {
 }
 
 func (d *Database) PlanSyncFromFile(filename string, specType string) ([]string, error) {
-	specContents, err := ioutil.ReadFile(filepath.Clean(filename))
+	specContents, err := os.ReadFile(filepath.Clean(filename))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read file")
 	}

--- a/pkg/generate/generate.go
+++ b/pkg/generate/generate.go
@@ -2,7 +2,6 @@ package generate
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -98,7 +97,7 @@ func (g *Generator) RunSync() error {
 
 		// If there was a outputdir set, write it, else print it
 		if g.OutputDir != "" {
-			if err := ioutil.WriteFile(filepath.Join(g.OutputDir, fmt.Sprintf("%s.yaml", sanitizeName(table.Name))), []byte(tableYAML), 0600); err != nil {
+			if err := os.WriteFile(filepath.Join(g.OutputDir, fmt.Sprintf("%s.yaml", sanitizeName(table.Name))), []byte(tableYAML), 0600); err != nil {
 				return err
 			}
 
@@ -123,7 +122,7 @@ func (g *Generator) RunSync() error {
 			return err
 		}
 
-		if err := ioutil.WriteFile(filepath.Join(g.OutputDir, "kustomization.yaml"), kustomizeDoc, 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(g.OutputDir, "kustomization.yaml"), kustomizeDoc, 0644); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
As of Go 1.16 io/ioutil library has been deprecated. its functions simply just call another functions(as you can see from the below links). i replace these function:

[ioutil/ReadFile](https://cs.opensource.google/go/go/+/refs/tags/go1.21.1:src/io/ioutil/ioutil.go;l=36) with os.ReadFile 
[ioutil/ReadAll](https://cs.opensource.google/go/go/+/refs/tags/go1.21.1:src/io/ioutil/ioutil.go;l=26) with io.ReadAll
[ioutil/WriteFile](https://cs.opensource.google/go/go/+/refs/tags/go1.21.1:src/io/ioutil/ioutil.go;l=45) with os.WriteFile