### PR TITLE
Don't include collation in DDL if it's not specified

### DIFF
--- a/integration/tests/mysql/add-collation/Makefile
+++ b/integration/tests/mysql/add-collation/Makefile
@@ -1,4 +1,4 @@
 include ../common.mk
 
 TEST_NAME := mysql-add-collation
-SPEC_FILE := ./specs/projects.yaml
+SPEC_FILE := ./specs

--- a/integration/tests/mysql/add-collation/expect.sql
+++ b/integration/tests/mysql/add-collation/expect.sql
@@ -1,1 +1,2 @@
 alter table projects convert to character set utf16 collate utf16_german2_ci;
+alter table `users` modify column `email` varchar (255) character set utf8mb4 not null;

--- a/integration/tests/mysql/add-collation/fixtures.sql
+++ b/integration/tests/mysql/add-collation/fixtures.sql
@@ -1,8 +1,9 @@
 create table users (
   id integer primary key not null,
   email varchar(255) not null
-);
+) CHARSET=latin1;
 
 create table projects (
-  id integer primary key not null
-);
+  id integer primary key not null,
+  data varchar(255) not null
+) CHARSET=latin1;

--- a/integration/tests/mysql/add-collation/specs/users.yaml
+++ b/integration/tests/mysql/add-collation/specs/users.yaml
@@ -1,16 +1,16 @@
 database: schemahero
-name: projects
+name: users
 schema:
   mysql:
     primaryKey: [id]
-    collation: utf16_german2_ci
+    collation: latin1_swedish_ci
     columns:
       - name: id
         type: integer
         constraints:
           notNull: true
-      - name: data
+      - name: email
         type: varchar (255)
-        charset: latin1
+        charset: utf8mb4
         constraints:
           notNull: true

--- a/integration/tests/mysql/column-set-default/expect.sql
+++ b/integration/tests/mysql/column-set-default/expect.sql
@@ -1,6 +1,6 @@
-alter table `users` modify column `account_type` varchar (10) collate utf8mb4_0900_ai_ci null default "trial";
+alter table `users` modify column `account_type` varchar (10) null default "trial";
 update `users` set `account_type`="trial" where `account_type` is null;
-alter table `users` modify column `account_type` varchar (10) collate utf8mb4_0900_ai_ci not null default "trial";
+alter table `users` modify column `account_type` varchar (10) not null default "trial";
 alter table `users` modify column `num_seats` int (11) null default "5";
 update `users` set `num_seats`="5" where `num_seats` is null;
 alter table `users` modify column `num_seats` int (11) not null default "5";

--- a/integration/tests/mysql/column-unset-default/expect.sql
+++ b/integration/tests/mysql/column-unset-default/expect.sql
@@ -1,2 +1,2 @@
-alter table `users` modify column `account_type` varchar (10) collate utf8mb4_0900_ai_ci;
+alter table `users` modify column `account_type` varchar (10);
 alter table `users` modify column `num_seats` int (11);

--- a/integration/tests/mysql/not-null/expect.sql
+++ b/integration/tests/mysql/not-null/expect.sql
@@ -1,1 +1,1 @@
-alter table `projects` modify column `icon_uri` varchar (255) collate utf8mb4_0900_ai_ci;
+alter table `projects` modify column `icon_uri` varchar (255);


### PR DESCRIPTION
When generating DDL to change `charset` on a column, SchemaHero will use the current collation if collation is not specified. This will not work when current collation is not compatible with desired charset.  There are two options:

1. Omit `collation` from DDL and let MySQL figure out the matching one
2. Lookup correct collation in `information_schema.character_sets` and use that one.  However, this is what MySQL will do automatically in option (1).

This PR uses the approach in (1)