### PR TITLE
ordered index postgres test case

### DIFF
--- a/integration/tests/postgres/Makefile
+++ b/integration/tests/postgres/Makefile
@@ -27,6 +27,7 @@ run: 11.18 12.13 13.9 14.6 15.1
 	make -C unique-constraint-drop run
 	make -C basic-seed run
 	make -C seed-with-many-rows run
+	make -C ordered-index-create run
 
 .PHONY: 12.13
 12.13: export PG_VERSION = 12.13
@@ -48,6 +49,7 @@ run: 11.18 12.13 13.9 14.6 15.1
 	make -C unique-constraint-drop run
 	make -C basic-seed run
 	make -C seed-with-many-rows run
+	make -C ordered-index-create run
 
 .PHONY: 13.9
 13.9: export PG_VERSION = 13.9
@@ -69,6 +71,7 @@ run: 11.18 12.13 13.9 14.6 15.1
 	make -C unique-constraint-drop run
 	make -C basic-seed run
 	make -C seed-with-many-rows run
+	make -C ordered-index-create run
 
 .PHONY: 14.6
 14.6: export PG_VERSION = 14.6
@@ -90,6 +93,7 @@ run: 11.18 12.13 13.9 14.6 15.1
 	make -C unique-constraint-drop run
 	make -C basic-seed run
 	make -C seed-with-many-rows run
+	make -C ordered-index-create run
 
 .PHONY: 15.1
 15.1: export PG_VERSION = 15.1
@@ -111,6 +115,7 @@ run: 11.18 12.13 13.9 14.6 15.1
 	make -C unique-constraint-drop run
 	make -C basic-seed run
 	make -C seed-with-many-rows run
+	make -C ordered-index-create run
 
 .PHONY: seed
 seed: export PG_VERSION = 15.1

--- a/integration/tests/postgres/Makefile
+++ b/integration/tests/postgres/Makefile
@@ -10,6 +10,7 @@ run: 11.18 12.13 13.9 14.6 15.1
 .PHONY: 11.18
 11.18: export PG_VERSION = 11.18-alpine
 11.18:
+	make -C ordered-index-create run
 	make -C alter-column-timezone run
 	make -C column-set-default run
 	make -C column-unset-default run
@@ -27,11 +28,11 @@ run: 11.18 12.13 13.9 14.6 15.1
 	make -C unique-constraint-drop run
 	make -C basic-seed run
 	make -C seed-with-many-rows run
-	make -C ordered-index-create run
 
 .PHONY: 12.13
 12.13: export PG_VERSION = 12.13
 12.13:
+	make -C ordered-index-create run
 	make -C column-set-default run
 	make -C column-unset-default run
 	make -C create-table run
@@ -49,11 +50,11 @@ run: 11.18 12.13 13.9 14.6 15.1
 	make -C unique-constraint-drop run
 	make -C basic-seed run
 	make -C seed-with-many-rows run
-	make -C ordered-index-create run
 
 .PHONY: 13.9
 13.9: export PG_VERSION = 13.9
 13.9:
+	make -C ordered-index-create run
 	make -C column-set-default run
 	make -C column-unset-default run
 	make -C create-table run
@@ -71,11 +72,11 @@ run: 11.18 12.13 13.9 14.6 15.1
 	make -C unique-constraint-drop run
 	make -C basic-seed run
 	make -C seed-with-many-rows run
-	make -C ordered-index-create run
 
 .PHONY: 14.6
 14.6: export PG_VERSION = 14.6
 14.6:
+	make -C ordered-index-create run
 	make -C column-set-default run
 	make -C column-unset-default run
 	make -C create-table run
@@ -93,11 +94,11 @@ run: 11.18 12.13 13.9 14.6 15.1
 	make -C unique-constraint-drop run
 	make -C basic-seed run
 	make -C seed-with-many-rows run
-	make -C ordered-index-create run
 
 .PHONY: 15.1
 15.1: export PG_VERSION = 15.1
 15.1:
+	make -C ordered-index-create run
 	make -C column-set-default run
 	make -C column-unset-default run
 	make -C create-table run
@@ -115,7 +116,6 @@ run: 11.18 12.13 13.9 14.6 15.1
 	make -C unique-constraint-drop run
 	make -C basic-seed run
 	make -C seed-with-many-rows run
-	make -C ordered-index-create run
 
 .PHONY: seed
 seed: export PG_VERSION = 15.1

--- a/integration/tests/postgres/ordered-index-create/Dockerfile
+++ b/integration/tests/postgres/ordered-index-create/Dockerfile
@@ -1,0 +1,7 @@
+FROM postgres
+
+ENV POSTGRES_USER=schemahero
+ENV POSTGRES_DB=schemahero
+
+## Insert fixtures
+COPY ./fixtures.sql /docker-entrypoint-initdb.d/

--- a/integration/tests/postgres/ordered-index-create/Makefile
+++ b/integration/tests/postgres/ordered-index-create/Makefile
@@ -1,0 +1,4 @@
+include ../common.mk
+
+TEST_NAME := postgres-index-create
+SPEC_FILE := ./specs/users.yaml

--- a/integration/tests/postgres/ordered-index-create/expect.sql
+++ b/integration/tests/postgres/ordered-index-create/expect.sql
@@ -1,0 +1,1 @@
+create unique index idx_users_email on users (email);

--- a/integration/tests/postgres/ordered-index-create/expect.sql
+++ b/integration/tests/postgres/ordered-index-create/expect.sql
@@ -1,1 +1,1 @@
-create unique index idx_users_email on users (email);
+create index users_tz_priority_2 on users (tz_2 desc, tz_3 asc);

--- a/integration/tests/postgres/ordered-index-create/fixtures.sql
+++ b/integration/tests/postgres/ordered-index-create/fixtures.sql
@@ -2,5 +2,8 @@ create table users (
   id integer primary key not null,
   email varchar(255) not null,
   "tz_1" timestamp,
-  "tz_2" timestamp with time zone
+  "tz_2" timestamp,
+  "tz_3" timestamp
 );
+
+create index users_tz_priority_1 on users (tz_1 desc, tz_2 asc);

--- a/integration/tests/postgres/ordered-index-create/fixtures.sql
+++ b/integration/tests/postgres/ordered-index-create/fixtures.sql
@@ -1,0 +1,6 @@
+create table users (
+  id integer primary key not null,
+  email varchar(255) not null,
+  "tz_1" timestamp,
+  "tz_2" timestamp with time zone
+);

--- a/integration/tests/postgres/ordered-index-create/specs/users.yaml
+++ b/integration/tests/postgres/ordered-index-create/specs/users.yaml
@@ -5,9 +5,14 @@ schema:
   postgres:
     primaryKey: [id]
     indexes:
-      - columns:
+      - name: users_tz_priority_1 # this index already exists and should not be modified
+        columns:
           - tz_1 desc
           - tz_2 asc
+      - name: users_tz_priority_2 # this index should be created fresh
+        columns:
+          - tz_2 desc
+          - tz_3 asc
     columns:
       - name: id
         type: integer
@@ -18,4 +23,6 @@ schema:
       - name: tz_1
         type: timestamp
       - name: tz_2
-        type: timestamp with time zone
+        type: timestamp
+      - name: tz_3
+        type: timestamp

--- a/integration/tests/postgres/ordered-index-create/specs/users.yaml
+++ b/integration/tests/postgres/ordered-index-create/specs/users.yaml
@@ -1,0 +1,21 @@
+database: schemahero
+name: users
+requires: []
+schema:
+  postgres:
+    primaryKey: [id]
+    indexes:
+      - columns:
+          - tz_1 desc
+          - tz_2 asc
+    columns:
+      - name: id
+        type: integer
+      - name: email
+        type: varchar(255)
+        constraints:
+          notNull: true
+      - name: tz_1
+        type: timestamp
+      - name: tz_2
+        type: timestamp with time zone

--- a/pkg/database/postgres/deploy.go
+++ b/pkg/database/postgres/deploy.go
@@ -310,6 +310,7 @@ DesiredIndexLoop:
 
 			if currentIndex.Name == index.Name {
 				matchedIndex = currentIndex
+				fmt.Printf("found existing index %v as match for %v\n", currentIndex, index)
 			}
 		}
 

--- a/pkg/database/postgres/index_test.go
+++ b/pkg/database/postgres/index_test.go
@@ -58,6 +58,16 @@ func Test_AddIndexStatement(t *testing.T) {
 			},
 			expectedStatement: `create unique index idx_t2_c1 on t2 (c1)`,
 		},
+		{
+			name:      "np name, one column, sorted",
+			tableName: "t2",
+			schemaIndex: &schemasv1alpha4.PostgresqlTableIndex{
+				Columns: []string{
+					"c1 desc",
+				},
+			},
+			expectedStatement: `create index idx_t2_c1_desc on t2 (c1 desc)`,
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/database/timescaledb/deploy.go
+++ b/pkg/database/timescaledb/deploy.go
@@ -180,6 +180,7 @@ DesiredIndexLoop:
 
 			if currentIndex.Name == index.Name {
 				matchedIndex = currentIndex
+				fmt.Printf("found existing index %v as match for %v\n", currentIndex, index)
 			}
 		}
 

--- a/pkg/database/timescaledb/deploy.go
+++ b/pkg/database/timescaledb/deploy.go
@@ -180,7 +180,6 @@ DesiredIndexLoop:
 
 			if currentIndex.Name == index.Name {
 				matchedIndex = currentIndex
-				fmt.Printf("found existing index %v as match for %v\n", currentIndex, index)
 			}
 		}
 

--- a/pkg/database/types/index.go
+++ b/pkg/database/types/index.go
@@ -120,7 +120,12 @@ func GenerateMysqlIndexName(tableName string, schemaIndex *schemasv1alpha4.Mysql
 }
 
 func GeneratePostgresqlIndexName(tableName string, schemaIndex *schemasv1alpha4.PostgresqlTableIndex) string {
-	return fmt.Sprintf("idx_%s_%s", tableName, strings.Join(schemaIndex.Columns, "_"))
+	safeCols := []string{}
+	for _, col := range schemaIndex.Columns {
+		safeCols = append(safeCols, strings.ReplaceAll(col, " ", "_"))
+	}
+
+	return fmt.Sprintf("idx_%s_%s", tableName, strings.Join(safeCols, "_"))
 }
 
 func GenerateSqliteIndexName(tableName string, schemaIndex *schemasv1alpha4.SqliteTableIndex) string {

--- a/pkg/database/types/index.go
+++ b/pkg/database/types/index.go
@@ -93,7 +93,7 @@ func PostgresqlSchemaIndexToIndex(schemaIndex *schemasv1alpha4.PostgresqlTableIn
 	}
 
 	index := Index{
-		Columns:  schemaIndex.Columns,
+		Columns:  cleanedCols,
 		Name:     schemaIndex.Name,
 		IsUnique: schemaIndex.IsUnique,
 	}

--- a/pkg/database/types/index.go
+++ b/pkg/database/types/index.go
@@ -82,6 +82,16 @@ func MysqlSchemaIndexToIndex(schemaIndex *schemasv1alpha4.MysqlTableIndex) *Inde
 }
 
 func PostgresqlSchemaIndexToIndex(schemaIndex *schemasv1alpha4.PostgresqlTableIndex) *Index {
+	cleanedCols := []string{}
+
+	for _, col := range schemaIndex.Columns {
+		cleanedCol := col
+		cleanedCol = strings.TrimSuffix(cleanedCol, " ASC")
+		cleanedCol = strings.TrimSuffix(cleanedCol, " asc")
+
+		cleanedCols = append(cleanedCols, cleanedCol)
+	}
+
 	index := Index{
 		Columns:  schemaIndex.Columns,
 		Name:     schemaIndex.Name,


### PR DESCRIPTION
Schemahero always requests to recreate `ASC` indexes in postgresql, which is exposed by this test case.