### PR TITLE
Don't include collation in DDL for tables if it's not specified

### DIFF
--- a/integration/tests/mysql/Makefile
+++ b/integration/tests/mysql/Makefile
@@ -29,7 +29,6 @@ run: 5.6.51 5.7.40 8.0.31
 	make -C auto-increment-add run
 	make -C auto-increment-drop run
 	make -C primary-key-change run
-	make -C add-charset run
 	make -C add-collation run
 	make -C remove-charset run
 	make -C add-charset run
@@ -64,7 +63,6 @@ run: 5.6.51 5.7.40 8.0.31
 	make -C auto-increment-add run
 	make -C auto-increment-drop run
 	make -C primary-key-change run
-	make -C add-charset run
 	make -C add-collation run
 	make -C remove-charset run
 	make -C add-charset run
@@ -100,7 +98,6 @@ run: 5.6.51 5.7.40 8.0.31
 	make -C auto-increment-create run
 	make -C auto-increment-add run
 	make -C auto-increment-drop run
-	make -C add-charset run
 	make -C add-collation run
 	make -C remove-charset run
 	make -C add-charset run

--- a/integration/tests/mysql/add-charset/Makefile
+++ b/integration/tests/mysql/add-charset/Makefile
@@ -1,4 +1,4 @@
 include ../common.mk
 
 TEST_NAME := mysql-add-charset
-SPEC_FILE := ./specs/projects.yaml
+SPEC_FILE := ./specs

--- a/integration/tests/mysql/add-charset/expect.sql
+++ b/integration/tests/mysql/add-charset/expect.sql
@@ -1,2 +1,2 @@
 alter table projects convert to character set utf16 collate utf16_general_ci;
-
+alter table users convert to character set utf8;

--- a/integration/tests/mysql/add-charset/fixtures.sql
+++ b/integration/tests/mysql/add-charset/fixtures.sql
@@ -1,7 +1,7 @@
 create table users (
   id integer primary key not null,
   email varchar(255) not null
-);
+) CHARSET=utf8mb4;
 
 create table projects (
   id integer primary key not null

--- a/integration/tests/mysql/add-charset/specs/users.yaml
+++ b/integration/tests/mysql/add-charset/specs/users.yaml
@@ -1,12 +1,15 @@
 database: schemahero
-name: projects
+name: users
 schema:
   mysql:
     primaryKey: [id]
-    defaultCharset: utf16
-    collation: utf16_general_ci
+    defaultCharset: utf8
     columns:
       - name: id
         type: integer
+        constraints:
+          notNull: true
+      - name: email
+        type: varchar (255)
         constraints:
           notNull: true

--- a/pkg/controller/table/reconcile_table.go
+++ b/pkg/controller/table/reconcile_table.go
@@ -179,7 +179,7 @@ func (r *ReconcileTable) plan(ctx context.Context, databaseInstance *databasesv1
 	// plan the schema
 	schemaStatements, err := db.PlanSyncTableSpec(&tableInstance.Spec)
 	if err != nil {
-		return reconcile.Result{}, errors.Wrap(err, "failed to plan sync")
+		return reconcile.Result{}, errors.Wrapf(err, "failed to plan sync for table %s", tableInstance.Name)
 	}
 
 	// plan the seed data
@@ -187,7 +187,7 @@ func (r *ReconcileTable) plan(ctx context.Context, databaseInstance *databasesv1
 	if databaseInstance.Spec.DeploySeedData {
 		stmts, err := db.PlanSyncSeedData(&tableInstance.Spec)
 		if err != nil {
-			return reconcile.Result{}, errors.Wrap(err, "failed to plan seed")
+			return reconcile.Result{}, errors.Wrapf(err, "failed to plan seed for table %s", tableInstance.Name)
 		}
 
 		seedStatements = append(seedStatements, stmts...)

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -257,7 +257,12 @@ func (d *Database) planTableSync(specContents []byte) ([]string, error) {
 		spec = &plainSpec
 	}
 
-	return d.PlanSyncTableSpec(spec)
+	plan, err := d.PlanSyncTableSpec(spec)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to plan table sync for %s", spec.Name)
+	}
+
+	return plan, nil
 }
 
 func (d *Database) SortSpecs(specs []types.Spec) {

--- a/pkg/database/mysql/deploy.go
+++ b/pkg/database/mysql/deploy.go
@@ -188,7 +188,7 @@ WHERE schema_name = ?`
 			row = m.db.QueryRow(query, mysqlTableSchema.DefaultCharset)
 			var defaultCollationForCharset string
 			if err := row.Scan(&defaultCollationForCharset); err != nil {
-				return nil, errors.Wrap(err, "failed to read default collation for charset")
+				return nil, errors.Wrapf(err, "failed to read default collation for charset %s", mysqlTableSchema.DefaultCharset)
 			}
 			mysqlTableSchema.Collation = defaultCollationForCharset
 		}
@@ -200,7 +200,7 @@ WHERE schema_name = ?`
 		row = m.db.QueryRow(query, mysqlTableSchema.Collation)
 		var collationCharset string
 		if err := row.Scan(&collationCharset); err != nil {
-			return nil, errors.Wrap(err, "failed to read charset for collation")
+			return nil, errors.Wrapf(err, "failed to read charset for collation %s", mysqlTableSchema.Collation)
 		}
 		mysqlTableSchema.DefaultCharset = collationCharset
 	}

--- a/pkg/database/mysql/deploy.go
+++ b/pkg/database/mysql/deploy.go
@@ -179,21 +179,19 @@ WHERE schema_name = ?`
 
 	// fill in defaults where needed
 	if mysqlTableSchema.Collation == "" {
+		// If charset didn't change, don't change collation. MySQL has it set to the default for the charset already.
+		if mysqlTableSchema.DefaultCharset == existingTableCharset {
+			return []string{}, nil
+		}
+
+		// If default charset is set, but not collation, let the database pick correct collation automatically
+		// Char sets that are aliases (like utf8) will not necessarily have a record in information_schema.character_sets,
+		// so we can't always look up the correct collation
 		if mysqlTableSchema.DefaultCharset == "" {
 			mysqlTableSchema.Collation = databaseCollation
 			mysqlTableSchema.DefaultCharset = databaseCharset
-		} else {
-			// get the default collation for the charset
-			query = `select DEFAULT_COLLATE_NAME from information_schema.character_sets where CHARACTER_SET_NAME = ?`
-			row = m.db.QueryRow(query, mysqlTableSchema.DefaultCharset)
-			var defaultCollationForCharset string
-			if err := row.Scan(&defaultCollationForCharset); err != nil {
-				return nil, errors.Wrapf(err, "failed to read default collation for charset %s", mysqlTableSchema.DefaultCharset)
-			}
-			mysqlTableSchema.Collation = defaultCollationForCharset
 		}
-	}
-	if mysqlTableSchema.DefaultCharset == "" {
+	} else if mysqlTableSchema.DefaultCharset == "" {
 		// here the collation must have been set, but not the charset
 		// get the charset associated with the collation
 		query = `select CHARACTER_SET_NAME from information_schema.collations where COLLATION_NAME = ?`
@@ -222,9 +220,15 @@ WHERE schema_name = ?`
 		return []string{}, nil
 	}
 
-	return []string{
-		fmt.Sprintf("alter table %s convert to character set %s collate %s", tableName, mysqlTableSchema.DefaultCharset, mysqlTableSchema.Collation),
-	}, nil
+	if mysqlTableSchema.Collation == "" {
+		return []string{
+			fmt.Sprintf("alter table %s convert to character set %s", tableName, mysqlTableSchema.DefaultCharset),
+		}, nil
+	} else {
+		return []string{
+			fmt.Sprintf("alter table %s convert to character set %s collate %s", tableName, mysqlTableSchema.DefaultCharset, mysqlTableSchema.Collation),
+		}, nil
+	}
 }
 
 // getDefaultCharsetAndCollationForTable will return the applied charset, collation for the specifed table


### PR DESCRIPTION
When generating DDL to change charset and collation for a table, SchemaHero will attempt to look up the correct collation for the given charset. However, this doesn't work when the charset is an alias, like utf8.

When changing charset, this will now allow MySQL to select the correct collation for the specified charset. If collation is specified, SchemaHero will generate DDL that uses the specified one.

Similar issue was resolved for individual column in https://github.com/schemahero/schemahero/pull/1022