### PR TITLE
Don't alter charset and collation if it's already default

### DIFF
--- a/integration/tests/mysql/Makefile
+++ b/integration/tests/mysql/Makefile
@@ -10,9 +10,9 @@ run: 5.6.51 5.7.40 8.0.31
 .PHONY: 5.6.51
 5.6.51: export MYSQL_VERSION = 5.6.51
 5.6.51:
+	make -C medium-blob run
 	make -C decimal run
 	make -C medium-text run
-	make -C medium-blob run
 	make -C column-set-default run
 	make -C column-unset-default run
 	make -C create-table run
@@ -44,9 +44,9 @@ run: 5.6.51 5.7.40 8.0.31
 .PHONY: 5.7.40
 5.7.40: export MYSQL_VERSION = 5.7.40
 5.7.40:
+	make -C medium-blob run
 	make -C decimal run
 	make -C medium-text run
-	make -C medium-blob run
 	make -C column-set-default run
 	make -C column-unset-default run
 	make -C create-table run
@@ -78,9 +78,9 @@ run: 5.6.51 5.7.40 8.0.31
 .PHONY: 8.0.31
 8.0.31: export MYSQL_VERSION = 8.0.31
 8.0.31:
+	make -C medium-blob run
 	make -C decimal run
 	make -C medium-text run
-	make -C medium-blob run
 	make -C column-set-default run
 	make -C column-unset-default run
 	make -C create-table run

--- a/integration/tests/mysql/common.mk
+++ b/integration/tests/mysql/common.mk
@@ -2,15 +2,18 @@ SHELL := /bin/bash
 DATABASE_IMAGE_NAME := schemahero/database
 DATABASE_CONTAINER_NAME := schemahero-database
 DRIVER := mysql
-URI := schemahero:password@tcp(localhost:13306)/schemahero?tls=false
+USERNAME := schemahero
+PASSWORD := password
+DATABASE := schemahero
+URI := $(USERNAME):$(PASSWORD)@tcp(localhost:13306)/$(DATABASE)?tls=false
 
 .PHONY: run
 run:
 	# Fixtures
-	docker build -t $(DATABASE_IMAGE_NAME) .
-	@-docker rm -f $(DATABASE_CONTAINER_NAME) > /dev/null 2>&1 ||:
+	@-docker rm -f $(DATABASE_CONTAINER_NAME) > /dev/null 2>&1 || true
+	docker build --no-cache -t $(DATABASE_IMAGE_NAME) .
 	docker run -p 13306:3306 --rm -d --name $(DATABASE_CONTAINER_NAME) $(DATABASE_IMAGE_NAME)
-	while ! docker exec $(DATABASE_CONTAINER_NAME) mysqladmin ping --silent; do sleep 1; done
+	while ! docker exec $(DATABASE_CONTAINER_NAME) mysql -u$(USERNAME) -p$(PASSWORD) $(DATABASE) -N -s -e "show tables" 2> /dev/null; do sleep 1; done
 	@sleep 10
 
 	# Plan
@@ -18,10 +21,16 @@ run:
 
 	# Verify
 	@echo Verifying results for $(TEST_NAME)
-	diff -B expect.sql out.sql
+	if ! diff -B expect.sql out.sql; then \
+		docker logs $(DATABASE_CONTAINER_NAME); \
+		exit 1; \
+	fi
 
 	# Apply
-	../../../../bin/kubectl-schemahero apply --driver=$(DRIVER) --uri="$(URI)" --ddl out.sql
+	if ! ../../../../bin/kubectl-schemahero apply --driver=$(DRIVER) --uri="$(URI)" --ddl out.sql; then \
+		docker logs $(DATABASE_CONTAINER_NAME); \
+		exit 1; \
+	fi
 
 	# Cleanup
 	@-sleep 5

--- a/pkg/controller/database/database_schema_controller.go
+++ b/pkg/controller/database/database_schema_controller.go
@@ -204,10 +204,5 @@ func (r *ReconcileDatabaseSchema) reconcileMysqlDatabaseSchema(databaseInstance 
 		return reconcile.Result{}, nil
 	}
 
-	query = fmt.Sprintf("alter database `%s` character set '%s' collate '%s'", cfg.DBName, defaultServerCharset, defaultServerCollation)
-	if _, err := db.Exec(query); err != nil {
-		return reconcile.Result{}, errors.Wrap(err, "failed to update database character set and collation")
-	}
-
 	return reconcile.Result{}, nil
 }


### PR DESCRIPTION
When no character set and no collation is specified in the db connection, Schemahero will always attempt to change these settings using the default database values by running the `alter database` statement.  This is a no-op operation, but it is still resource consuming and can lock the database for a long period of time.