### PR TITLE
Reducing code duplication and adding some connection tests

### DIFF
--- a/pkg/apis/databases/v1alpha4/connection.go
+++ b/pkg/apis/databases/v1alpha4/connection.go
@@ -288,6 +288,10 @@ func (d *Database) getConnectionFromURI(ctx context.Context) (string, string, er
 }
 
 func (d *Database) addQueryStringParameter(ctx context.Context, driver string, queryParams *[]string, label string, key string, valueOrValueFrom *ValueOrValueFrom) error {
+	if valueOrValueFrom == nil {
+		return errors.New("valueOrValueFrom must not be nil")
+	}
+
 	if !valueOrValueFrom.IsEmpty() {
 		value, err := d.getValueFromValueOrValueFrom(ctx, driver, valueOrValueFrom)
 		if err != nil {
@@ -300,6 +304,9 @@ func (d *Database) addQueryStringParameter(ctx context.Context, driver string, q
 
 // getValueFromValueOrValueFrom returns the resolved value, or an error
 func (d *Database) getValueFromValueOrValueFrom(ctx context.Context, driver string, valueOrValueFrom *ValueOrValueFrom) (string, error) {
+	if valueOrValueFrom == nil {
+		return "", errors.New("valueOrValueFrom must not be nil")
+	}
 
 	// if the value is static, return it
 	if valueOrValueFrom.Value != "" {

--- a/pkg/apis/databases/v1alpha4/connection.go
+++ b/pkg/apis/databases/v1alpha4/connection.go
@@ -19,12 +19,14 @@ package v1alpha4
 import (
 	"context"
 	"fmt"
-	"github.com/pkg/errors"
-	"github.com/schemahero/schemahero/pkg/config"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 	"net/url"
 	"strings"
+
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/schemahero/schemahero/pkg/config"
 )
 
 // GetConnection returns driver name, uri, and any error

--- a/pkg/apis/databases/v1alpha4/connection_cassandra_test.go
+++ b/pkg/apis/databases/v1alpha4/connection_cassandra_test.go
@@ -1,0 +1,32 @@
+package v1alpha4
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDatabase_Cassandra_GetConnection_SimpleParams(t *testing.T) {
+	d := Database{
+		Spec: DatabaseSpec{
+			Connection: DatabaseConnection{
+				Cassandra: &CassandraConnection{
+					Hosts:    []string{"host1", "host2"},
+					Keyspace: NewValue("keyspace"),
+					Username: NewValue("username"),
+					Password: NewValue("password"),
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+
+	driver, value, err := d.GetConnection(ctx)
+
+	// populate the strings and change NotNil to Nil once implemented
+	assert.Equal(t, "", driver)
+	assert.Equal(t, "", value)
+	assert.NotNil(t, err)
+}

--- a/pkg/apis/databases/v1alpha4/connection_cockroachdb_test.go
+++ b/pkg/apis/databases/v1alpha4/connection_cockroachdb_test.go
@@ -1,0 +1,52 @@
+package v1alpha4
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDatabase_CockroachDB_GetConnection_SimpleURI(t *testing.T) {
+	d := Database{
+		Spec: DatabaseSpec{
+			Connection: DatabaseConnection{
+				CockroachDB: &CockroachDBConnection{
+					URI: NewValue("user:password@host:5432/dbname"),
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+
+	driver, value, err := d.GetConnection(ctx)
+
+	assert.Equal(t, "cockroachdb", driver)
+	assert.Equal(t, "user:password@host:5432/dbname", value)
+	assert.Nil(t, err)
+}
+
+func TestDatabase_CockroachDB_GetConnection_SimpleParams(t *testing.T) {
+	d := Database{
+		Spec: DatabaseSpec{
+			Connection: DatabaseConnection{
+				CockroachDB: &CockroachDBConnection{
+					Host:     NewValue("host"),
+					Port:     NewValue("5432"),
+					User:     NewValue("user"),
+					Password: NewValue("password"),
+					DBName:   NewValue("dbname"),
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+
+	driver, value, err := d.GetConnection(ctx)
+
+	assert.Equal(t, "cockroachdb", driver)
+	assert.Equal(t, "postgres://user:password@host:5432/dbname", value)
+	assert.Nil(t, err)
+}

--- a/pkg/apis/databases/v1alpha4/connection_mysql_test.go
+++ b/pkg/apis/databases/v1alpha4/connection_mysql_test.go
@@ -1,0 +1,52 @@
+package v1alpha4
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDatabase_Mysql_GetConnection_SimpleURI(t *testing.T) {
+	d := Database{
+		Spec: DatabaseSpec{
+			Connection: DatabaseConnection{
+				Mysql: &MysqlConnection{
+					URI: NewValue("user:password@host:5432/dbname"),
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+
+	driver, value, err := d.GetConnection(ctx)
+
+	assert.Equal(t, "mysql", driver)
+	assert.Equal(t, "user:password@host:5432/dbname", value)
+	assert.Nil(t, err)
+}
+
+func TestDatabase_Mysql_GetConnection_SimpleParams(t *testing.T) {
+	d := Database{
+		Spec: DatabaseSpec{
+			Connection: DatabaseConnection{
+				Mysql: &MysqlConnection{
+					Host:     NewValue("host"),
+					Port:     NewValue("5432"),
+					User:     NewValue("user"),
+					Password: NewValue("password"),
+					DBName:   NewValue("dbname"),
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+
+	driver, value, err := d.GetConnection(ctx)
+
+	assert.Equal(t, "mysql", driver)
+	assert.Equal(t, "user:password@tcp(host:5432)/dbname", value)
+	assert.Nil(t, err)
+}

--- a/pkg/apis/databases/v1alpha4/connection_postgres_test.go
+++ b/pkg/apis/databases/v1alpha4/connection_postgres_test.go
@@ -2,8 +2,9 @@ package v1alpha4
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDatabase_Postgres_GetConnection_SimpleURI(t *testing.T) {

--- a/pkg/apis/databases/v1alpha4/connection_postgres_test.go
+++ b/pkg/apis/databases/v1alpha4/connection_postgres_test.go
@@ -1,0 +1,76 @@
+package v1alpha4
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestDatabase_Postgres_GetConnection_SimpleURI(t *testing.T) {
+	d := Database{
+		Spec: DatabaseSpec{
+			Connection: DatabaseConnection{
+				Postgres: &PostgresConnection{
+					URI: NewValue("postgres://user:password@host:5432/dbname"),
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+
+	driver, value, err := d.GetConnection(ctx)
+
+	assert.Equal(t, "postgres", driver)
+	assert.Equal(t, "postgres://user:password@host:5432/dbname", value)
+	assert.Nil(t, err)
+}
+
+func TestDatabase_Postgres_GetConnection_SimpleParams(t *testing.T) {
+	d := Database{
+		Spec: DatabaseSpec{
+			Connection: DatabaseConnection{
+				Postgres: &PostgresConnection{
+					Host:     NewValue("host"),
+					Port:     NewValue("5432"),
+					User:     NewValue("user"),
+					Password: NewValue("password"),
+					DBName:   NewValue("dbname"),
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+
+	driver, value, err := d.GetConnection(ctx)
+
+	assert.Equal(t, "postgres", driver)
+	assert.Equal(t, "postgres://user:password@host:5432/dbname", value)
+	assert.Nil(t, err)
+}
+
+func TestDatabase_Postgres_GetConnection_SimpleParamsWithSchema(t *testing.T) {
+	d := Database{
+		Spec: DatabaseSpec{
+			Connection: DatabaseConnection{
+				Postgres: &PostgresConnection{
+					Host:          NewValue("host"),
+					Port:          NewValue("5432"),
+					User:          NewValue("user"),
+					Password:      NewValue("password"),
+					DBName:        NewValue("dbname"),
+					CurrentSchema: NewValue("public"),
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+
+	driver, value, err := d.GetConnection(ctx)
+
+	assert.Equal(t, "postgres", driver)
+	assert.Equal(t, "postgres://user:password@host:5432/dbname?search_path=public", value)
+	assert.Nil(t, err)
+}

--- a/pkg/apis/databases/v1alpha4/connection_rqlite_test.go
+++ b/pkg/apis/databases/v1alpha4/connection_rqlite_test.go
@@ -1,0 +1,51 @@
+package v1alpha4
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDatabase_RQLite_GetConnection_SimpleURI(t *testing.T) {
+	d := Database{
+		Spec: DatabaseSpec{
+			Connection: DatabaseConnection{
+				RQLite: &RqliteConnection{
+					URI: NewValue("user:password@host:5432/dbname"),
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+
+	driver, value, err := d.GetConnection(ctx)
+
+	assert.Equal(t, "rqlite", driver)
+	assert.Equal(t, "user:password@host:5432/dbname", value)
+	assert.Nil(t, err)
+}
+
+func TestDatabase_RQLite_GetConnection_SimpleParams(t *testing.T) {
+	d := Database{
+		Spec: DatabaseSpec{
+			Connection: DatabaseConnection{
+				RQLite: &RqliteConnection{
+					Host:     NewValue("host"),
+					Port:     NewValue("5432"),
+					User:     NewValue("user"),
+					Password: NewValue("password"),
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+
+	driver, value, err := d.GetConnection(ctx)
+
+	assert.Equal(t, "rqlite", driver)
+	assert.Equal(t, "https://user:password@host:5432/", value)
+	assert.Nil(t, err)
+}

--- a/pkg/apis/databases/v1alpha4/connection_timescaledb_test.go
+++ b/pkg/apis/databases/v1alpha4/connection_timescaledb_test.go
@@ -1,0 +1,52 @@
+package v1alpha4
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDatabase_TimescaleDB_GetConnection_SimpleURI(t *testing.T) {
+	d := Database{
+		Spec: DatabaseSpec{
+			Connection: DatabaseConnection{
+				TimescaleDB: &PostgresConnection{
+					URI: NewValue("user:password@host:5432/dbname"),
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+
+	driver, value, err := d.GetConnection(ctx)
+
+	assert.Equal(t, "timescaledb", driver)
+	assert.Equal(t, "user:password@host:5432/dbname", value)
+	assert.Nil(t, err)
+}
+
+func TestDatabase_TimescaleDB_GetConnection_SimpleParams(t *testing.T) {
+	d := Database{
+		Spec: DatabaseSpec{
+			Connection: DatabaseConnection{
+				TimescaleDB: &PostgresConnection{
+					Host:     NewValue("host"),
+					Port:     NewValue("5432"),
+					User:     NewValue("user"),
+					Password: NewValue("password"),
+					DBName:   NewValue("dbname"),
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+
+	driver, value, err := d.GetConnection(ctx)
+
+	assert.Equal(t, "timescaledb", driver)
+	assert.Equal(t, "postgres://user:password@host:5432/dbname", value)
+	assert.Nil(t, err)
+}

--- a/pkg/apis/databases/v1alpha4/ssm_connection.go
+++ b/pkg/apis/databases/v1alpha4/ssm_connection.go
@@ -29,7 +29,7 @@ import (
 )
 
 // getSSMConnection returns the driver, the resolved value, and any error
-func (d *Database) getSSMConnection(ctx context.Context, clientset *kubernetes.Clientset, driver string, valueOrValueFrom ValueOrValueFrom) (string, string, error) {
+func (d *Database) getSSMConnection(ctx context.Context, clientset *kubernetes.Clientset, driver string, valueOrValueFrom *ValueOrValueFrom) (string, string, error) {
 	region := valueOrValueFrom.ValueFrom.SSM.Region
 	if region == "" {
 		region = "us-east-1"

--- a/pkg/apis/databases/v1alpha4/value_or_value_from.go
+++ b/pkg/apis/databases/v1alpha4/value_or_value_from.go
@@ -4,6 +4,23 @@ import (
 	"github.com/pkg/errors"
 )
 
+func NewValue(value string) ValueOrValueFrom {
+	return ValueOrValueFrom{
+		Value: value,
+	}
+}
+
+func NewValueFromSecret(secretName string, secretKey string) ValueOrValueFrom {
+	return ValueOrValueFrom{
+		ValueFrom: &ValueFrom{
+			SecretKeyRef: &SecretKeyRef{
+				Name: secretName,
+				Key:  secretKey,
+			},
+		},
+	}
+}
+
 type ValueOrValueFrom struct {
 	Value     string     `json:"value,omitempty" yaml:"value,omitempty"`
 	ValueFrom *ValueFrom `json:"valueFrom,omitempty" yaml:"valueFrom,omitempty"`

--- a/pkg/apis/databases/v1alpha4/vault_connection.go
+++ b/pkg/apis/databases/v1alpha4/vault_connection.go
@@ -21,8 +21,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
 	"text/template"
 
 	"github.com/pkg/errors"
@@ -31,10 +32,10 @@ import (
 )
 
 // getVaultConnection returns the driver, the resolved URI, or an error
-func (d *Database) getVaultConnection(ctx context.Context, clientset kubernetes.Interface, driver string, valueOrValueFrom ValueOrValueFrom) (string, string, error) {
+func (d *Database) getVaultConnection(ctx context.Context, clientset kubernetes.Interface, driver string, valueOrValueFrom *ValueOrValueFrom) (string, string, error) {
 	// if the value is in vault and we are using the vault injector, just read the file
 	if valueOrValueFrom.ValueFrom.Vault.AgentInject {
-		vaultInjectedFileContents, err := ioutil.ReadFile("/vault/secrets/schemaherouri")
+		vaultInjectedFileContents, err := os.ReadFile("/vault/secrets/schemaherouri")
 		if err != nil {
 			return "", "", errors.Wrap(err, "failed to read vault injected file")
 		}
@@ -102,7 +103,7 @@ func (d *Database) getVaultConnection(ctx context.Context, clientset kubernetes.
 		Auth: LoginResponseAuth{},
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", "", errors.Wrap(err, "failed to read response body")
 	}
@@ -133,7 +134,7 @@ func (d *Database) getVaultConnection(ctx context.Context, clientset kubernetes.
 		Data: map[string]interface{}{},
 	}
 
-	b, err = ioutil.ReadAll(resp.Body)
+	b, err = io.ReadAll(resp.Body)
 	if err != nil {
 		return "", "", errors.Wrap(err, "failed to read body")
 	}
@@ -197,7 +198,7 @@ func getConnectionURITemplate(vault *Vault, token string, dbName string) (string
 			Data: ConfigDataResponse{},
 		}
 
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return "", errors.Wrap(err, "failed to read body")
 		}

--- a/pkg/apis/databases/v1alpha4/vault_connection_test.go
+++ b/pkg/apis/databases/v1alpha4/vault_connection_test.go
@@ -19,14 +19,14 @@ func TestGetConnectionURIFromTemplate(t *testing.T) {
 		driver           string
 		tmpUser          string
 		tmpPassword      string
-		valueOrValueFrom ValueOrValueFrom
+		valueOrValueFrom *ValueOrValueFrom
 	}{
 		{
 			name:        "uses_specified_template",
 			driver:      "mysql",
 			tmpUser:     "someuser",
 			tmpPassword: "p@ssw0rd",
-			valueOrValueFrom: ValueOrValueFrom{
+			valueOrValueFrom: &ValueOrValueFrom{
 				ValueFrom: &ValueFrom{
 					Vault: &Vault{
 						ConnectionTemplate: "postgresql://{{ .username }}:{{ .password }}@postgresql:5432/schema",
@@ -80,7 +80,7 @@ func TestGetConnectionURIFromTemplate(t *testing.T) {
 			test.valueOrValueFrom.ValueFrom.Vault.Endpoint = srv.URL
 
 			d := &Database{}
-			_, uri, err := d.getVaultConnection(context.TODO(), fake.NewSimpleClientset(sa, sc), test.driver, test.valueOrValueFrom)
+			_, uri, err := d.getVaultConnection(context.TODO(), fake.NewClientset(sa, sc), test.driver, test.valueOrValueFrom)
 			assert.NoError(t, err)
 
 			assert.Equal(t, fmt.Sprintf("postgresql://%s:%s@postgresql:5432/schema", test.tmpUser, test.tmpPassword), uri)
@@ -94,14 +94,14 @@ func TestGetConnectionURIFromVault(t *testing.T) {
 		driver           string
 		tmpUser          string
 		tmpPassword      string
-		valueOrValueFrom ValueOrValueFrom
+		valueOrValueFrom *ValueOrValueFrom
 	}{
 		{
 			name:        "uses_template_from_vault",
 			driver:      "mysql",
 			tmpUser:     "someuser",
 			tmpPassword: "p@ssw0rd",
-			valueOrValueFrom: ValueOrValueFrom{
+			valueOrValueFrom: &ValueOrValueFrom{
 				ValueFrom: &ValueFrom{
 					Vault: &Vault{
 						Secret: "secret",
@@ -164,7 +164,7 @@ func TestGetConnectionURIFromVault(t *testing.T) {
 
 			test.valueOrValueFrom.ValueFrom.Vault.Endpoint = s.URL
 
-			_, uri, err := d.getVaultConnection(context.TODO(), fake.NewSimpleClientset(sa, sc), test.driver, test.valueOrValueFrom)
+			_, uri, err := d.getVaultConnection(context.TODO(), fake.NewClientset(sa, sc), test.driver, test.valueOrValueFrom)
 			assert.NoError(t, err)
 
 			assert.Equal(t, fmt.Sprintf("postgresql://%s:%s@postgresql:5432/schema", test.tmpUser, test.tmpPassword), uri)
@@ -177,12 +177,12 @@ func TestKubernetesAuthEndpoint(t *testing.T) {
 		name                     string
 		kubernetesAuthEndpoint   string
 		expectedKubeAuthEndpoint string
-		valueOrValueFrom         ValueOrValueFrom
+		valueOrValueFrom         *ValueOrValueFrom
 	}{
 		{
 			name:                     "uses_default_endpoint",
 			expectedKubeAuthEndpoint: "/v1/auth/kubernetes/login",
-			valueOrValueFrom: ValueOrValueFrom{
+			valueOrValueFrom: &ValueOrValueFrom{
 				ValueFrom: &ValueFrom{
 					Vault: &Vault{
 						ConnectionTemplate: "postgresql://{{ .username }}:{{ .password }}@postgresql:5432/schema",
@@ -194,7 +194,7 @@ func TestKubernetesAuthEndpoint(t *testing.T) {
 		{
 			name:                     "uses_specified_endpoint",
 			expectedKubeAuthEndpoint: "/v1/auth/kubernetes_custom/login",
-			valueOrValueFrom: ValueOrValueFrom{
+			valueOrValueFrom: &ValueOrValueFrom{
 				ValueFrom: &ValueFrom{
 					Vault: &Vault{
 						ConnectionTemplate:     "postgresql://{{ .username }}:{{ .password }}@postgresql:5432/schema",
@@ -248,7 +248,7 @@ func TestKubernetesAuthEndpoint(t *testing.T) {
 				},
 			}
 
-			_, _, err := d.getVaultConnection(context.TODO(), fake.NewSimpleClientset(sa, sc), "postgresql", test.valueOrValueFrom)
+			_, _, err := d.getVaultConnection(context.TODO(), fake.NewClientset(sa, sc), "postgresql", test.valueOrValueFrom)
 
 			assert.NoError(t, err)
 			assert.True(t, endpointReached, "Expected endpoint %s to be hit, but instead we called %s", test.expectedKubeAuthEndpoint, actualEndpoint)


### PR DESCRIPTION
I'm working towards supporting mTLS connections with Postgres. This is my second PR in that direction.

A few improvements here:
* There was a lot of code repetition in connection.go. I introduced a method to help assemble query parameters.
* Some refactoring to improve testability of the connection code.
* Unit tests for connections. There were no tests at all on the connection code!
* Addressed some simple deprecations

In a future PRs, I plan to add the additional properties to the PostgresConnection type along with supporting code. That will require some ValueFrom objects referencing secrets, so I also plan to introduce GoMock, which will simplify testing of that functionality.