### PR TITLE
improve migration describe output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ bin
 *.swp
 *.swo
 *~
+.claude
 
 dist/
 

--- a/pkg/cli/schemaherokubectlcli/describe_migration.go
+++ b/pkg/cli/schemaherokubectlcli/describe_migration.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	schemasv1alpha4 "github.com/schemahero/schemahero/pkg/apis/schemas/v1alpha4"
 	schemasclientv1alpha4 "github.com/schemahero/schemahero/pkg/client/schemaheroclientset/typed/schemas/v1alpha4"
 	"github.com/schemahero/schemahero/pkg/config"
 	"github.com/spf13/cobra"
@@ -82,24 +83,41 @@ func DescribeMigrationCmd() *cobra.Command {
 				}
 
 				fmt.Printf("\nMigration Name: %s\n\n", foundMigration.Name)
+				
+				// Display status information
+				fmt.Printf("Status: %s\n", foundMigration.Status.Phase)
+				if foundMigration.Status.ApprovedAt > 0 {
+					fmt.Printf("Approved at: %s\n", time.Unix(foundMigration.Status.ApprovedAt, 0).Format(time.RFC3339))
+				}
+				if foundMigration.Status.ExecutedAt > 0 {
+					fmt.Printf("Applied at: %s\n", time.Unix(foundMigration.Status.ExecutedAt, 0).Format(time.RFC3339))
+				}
+				if foundMigration.Status.RejectedAt > 0 {
+					fmt.Printf("Rejected at: %s\n", time.Unix(foundMigration.Status.RejectedAt, 0).Format(time.RFC3339))
+				}
+				fmt.Println("")
+
 				fmt.Printf("Generated DDL Statement (generated at %s): \n  %s\n",
 					time.Unix(foundMigration.Status.PlannedAt, 0).Format(time.RFC3339),
 					foundMigration.Spec.GeneratedDDL)
 
-				fmt.Println("")
-				fmt.Println("To apply this migration:")
-				fmt.Printf(`  %s approve migration %s`, baseCommand, foundMigration.Name)
-				fmt.Println("")
+				// Only show approval/action commands for migrations that haven't been approved or applied
+				if foundMigration.Status.Phase == schemasv1alpha4.Planned {
+					fmt.Println("")
+					fmt.Println("To apply this migration:")
+					fmt.Printf(`  %s approve migration %s`, baseCommand, foundMigration.Name)
+					fmt.Println("")
 
-				fmt.Println("")
-				fmt.Println("To recalculate this migration against the current schema:")
-				fmt.Printf(`  %s recalculate migration %s`, baseCommand, foundMigration.Name)
-				fmt.Println("")
+					fmt.Println("")
+					fmt.Println("To recalculate this migration against the current schema:")
+					fmt.Printf(`  %s recalculate migration %s`, baseCommand, foundMigration.Name)
+					fmt.Println("")
 
-				fmt.Println("")
-				fmt.Println("To deny and cancel this migration:")
-				fmt.Printf(`  %s reject migration %s`, baseCommand, foundMigration.Name)
-				fmt.Println("")
+					fmt.Println("")
+					fmt.Println("To deny and cancel this migration:")
+					fmt.Printf(`  %s reject migration %s`, baseCommand, foundMigration.Name)
+					fmt.Println("")
+				}
 
 				return nil
 			}

--- a/pkg/cli/schemaherokubectlcli/describe_migration.go
+++ b/pkg/cli/schemaherokubectlcli/describe_migration.go
@@ -83,9 +83,13 @@ func DescribeMigrationCmd() *cobra.Command {
 				}
 
 				fmt.Printf("\nMigration Name: %s\n\n", foundMigration.Name)
-				
+
+				fmt.Printf("Generated DDL Statement (generated at %s): \n  %s\n",
+					time.Unix(foundMigration.Status.PlannedAt, 0).Format(time.RFC3339),
+					foundMigration.Spec.GeneratedDDL)
+
 				// Display status information
-				fmt.Printf("Status: %s\n", foundMigration.Status.Phase)
+				fmt.Printf("\nStatus: %s\n", foundMigration.Status.Phase)
 				if foundMigration.Status.ApprovedAt > 0 {
 					fmt.Printf("Approved at: %s\n", time.Unix(foundMigration.Status.ApprovedAt, 0).Format(time.RFC3339))
 				}
@@ -95,11 +99,6 @@ func DescribeMigrationCmd() *cobra.Command {
 				if foundMigration.Status.RejectedAt > 0 {
 					fmt.Printf("Rejected at: %s\n", time.Unix(foundMigration.Status.RejectedAt, 0).Format(time.RFC3339))
 				}
-				fmt.Println("")
-
-				fmt.Printf("Generated DDL Statement (generated at %s): \n  %s\n",
-					time.Unix(foundMigration.Status.PlannedAt, 0).Format(time.RFC3339),
-					foundMigration.Spec.GeneratedDDL)
 
 				// Only show approval/action commands for migrations that haven't been approved or applied
 				if foundMigration.Status.Phase == schemasv1alpha4.Planned {


### PR DESCRIPTION
Currently the describe output for completed migrations makes no mention of this fact at all.

This PR updates the `kubectl schemahero describe migration` output to include when the migration was approved, applied, or rejected - and to only show the "how to approve/recalculate/reject" info if the migration is pending. 

```
Migration Name: DEMO

Generated DDL Statement (generated at 2024-02-15T15:11:32-05:00):
  DEMO SQL
Status: EXECUTED
Approved at: 2024-02-15T15:11:32-05:00
Applied at: 2024-02-15T15:11:32-05:00
```