### PR TITLE
Fix docker tags

### DIFF
--- a/.github/workflows/tagged-release.yaml
+++ b/.github/workflows/tagged-release.yaml
@@ -166,11 +166,25 @@ jobs:
         uses: actions/checkout@v4
       - id: get_version
         uses: battila7/get-version-action@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: schemaherodeploy
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Docker meta for manager
+        id: meta-manager
+        uses: docker/metadata-action@v5
+        with:
+          images: index.docker.io/schemahero/schemahero-manager
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable=${{ steps.get_version.outputs.prerelease == '' }}
       - name: Build and push
         id: release-manager
         uses: docker/build-push-action@v5
@@ -178,8 +192,10 @@ jobs:
           context: .
           file: deploy/Dockerfile.multiarch
           target: manager
+          platforms: linux/amd64,linux/arm64
           push: true
-          tags: index.docker.io/schemahero/schemahero-manager:${{ steps.get_version.outputs.version-without-v }}
+          tags: ${{ steps.meta-manager.outputs.tags }}
+          labels: ${{ steps.meta-manager.outputs.labels }}
 
   build-docker-schemahero:
     runs-on: ubuntu-latest
@@ -200,12 +216,26 @@ jobs:
       - id: get_version
         uses: battila7/get-version-action@v2
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: schemaherodeploy
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
+      - name: Docker meta for schemahero
+        id: meta-schemahero
+        uses: docker/metadata-action@v5
+        with:
+          images: index.docker.io/schemahero/schemahero
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable=${{ steps.get_version.outputs.prerelease == '' }}
       - name: Build and push
         id: release-schemahero
         uses: docker/build-push-action@v5
@@ -213,8 +243,10 @@ jobs:
           context: .
           file: deploy/Dockerfile.multiarch
           target: schemahero
+          platforms: linux/amd64,linux/arm64
           push: true
-          tags: index.docker.io/schemahero/schemahero:${{ steps.get_version.outputs.version-without-v }}
+          tags: ${{ steps.meta-schemahero.outputs.tags }}
+          labels: ${{ steps.meta-schemahero.outputs.labels }}
 
   github-release-tarballs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Since we went to the buildx action, we lost a few things in 0.20:

1. we used to push 0, 0.20, 0.20.0 and latest, but now just push the specific tag (0.20.0). 
2. we lost multi-arch images

This PR adds both of these things back