### PR TITLE
fix: role lacks new CRDs

### DIFF
--- a/pkg/controller/database/rbac.go
+++ b/pkg/controller/database/rbac.go
@@ -164,6 +164,36 @@ func (r *ReconcileDatabase) reconcileRBACRole(ctx context.Context, databaseInsta
 					Resources: []string{"views/status"},
 					Verbs:     metav1.Verbs{"get", "update", "patch"},
 				},
+				{
+					APIGroups: []string{"schemas.schemahero.io"},
+					Resources: []string{"functions"},
+					Verbs:     metav1.Verbs{"get", "list", "watch", "create", "update", "patch", "delete"},
+				},
+				{
+					APIGroups: []string{"schemas.schemahero.io"},
+					Resources: []string{"functions/status"},
+					Verbs:     metav1.Verbs{"get", "update", "patch"},
+				},
+				{
+					APIGroups: []string{"schemas.schemahero.io"},
+					Resources: []string{"databaseextensions"},
+					Verbs:     metav1.Verbs{"get", "list", "watch", "create", "update", "patch", "delete"},
+				},
+				{
+					APIGroups: []string{"schemas.schemahero.io"},
+					Resources: []string{"databaseextensions/status"},
+					Verbs:     metav1.Verbs{"get", "update", "patch"},
+				},
+				{
+					APIGroups: []string{"schemas.schemahero.io"},
+					Resources: []string{"datatypes"},
+					Verbs:     metav1.Verbs{"get", "list", "watch", "create", "update", "patch", "delete"},
+				},
+				{
+					APIGroups: []string{"schemas.schemahero.io"},
+					Resources: []string{"datatypes/status"},
+					Verbs:     metav1.Verbs{"get", "update", "patch"},
+				},
 			},
 		}
 

--- a/pkg/controller/databaseextension/database_extension_controller.go
+++ b/pkg/controller/databaseextension/database_extension_controller.go
@@ -115,6 +115,13 @@ func (r *ReconcileDatabaseExtension) getDatabaseFromExtension(ctx context.Contex
 	return database, nil
 }
 
+// Reconcile reads that state of the cluster for a DatabaseExtension object and makes changes based on the state read
+// and what is in the DatabaseExtension.Spec
+// Automatically generate RBAC rules to allow the Controller to read and write Deployments
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=apps,resources=deployments/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=schemas.schemahero.io,resources=databaseextensions,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=schemas.schemahero.io,resources=databaseextensions/status,verbs=get;update;patch
 func (r *ReconcileDatabaseExtension) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	logger.Debug("reconciling database extension",
 		zap.String("kind", "databaseextension"),

--- a/pkg/controller/function/function_controller.go
+++ b/pkg/controller/function/function_controller.go
@@ -115,6 +115,13 @@ func (r *ReconcileFunction) getDatabaseFromFunction(ctx context.Context, functio
 	return database, nil
 }
 
+// Reconcile reads that state of the cluster for a Function object and makes changes based on the state read
+// and what is in the Function.Spec
+// Automatically generate RBAC rules to allow the Controller to read and write Deployments
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=apps,resources=deployments/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=schemas.schemahero.io,resources=functions,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=schemas.schemahero.io,resources=functions/status,verbs=get;update;patch
 func (r *ReconcileFunction) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	logger.Debug("reconciling function",
 		zap.String("kind", "function"),

--- a/pkg/installer/rbac.go
+++ b/pkg/installer/rbac.go
@@ -129,6 +129,36 @@ func clusterRole() *rbacv1.ClusterRole {
 				Resources: []string{"views/status"},
 				Verbs:     metav1.Verbs{"get", "update", "patch"},
 			},
+			{
+				APIGroups: []string{"schemas.schemahero.io"},
+				Resources: []string{"functions"},
+				Verbs:     metav1.Verbs{"get", "list", "watch", "create", "update", "patch", "delete"},
+			},
+			{
+				APIGroups: []string{"schemas.schemahero.io"},
+				Resources: []string{"functions/status"},
+				Verbs:     metav1.Verbs{"get", "update", "patch"},
+			},
+			{
+				APIGroups: []string{"schemas.schemahero.io"},
+				Resources: []string{"databaseextensions"},
+				Verbs:     metav1.Verbs{"get", "list", "watch", "create", "update", "patch", "delete"},
+			},
+			{
+				APIGroups: []string{"schemas.schemahero.io"},
+				Resources: []string{"databaseextensions/status"},
+				Verbs:     metav1.Verbs{"get", "update", "patch"},
+			},
+			{
+				APIGroups: []string{"schemas.schemahero.io"},
+				Resources: []string{"datatypes"},
+				Verbs:     metav1.Verbs{"get", "list", "watch", "create", "update", "patch", "delete"},
+			},
+			{
+				APIGroups: []string{"schemas.schemahero.io"},
+				Resources: []string{"datatypes/status"},
+				Verbs:     metav1.Verbs{"get", "update", "patch"},
+			},
 		},
 	}
 


### PR DESCRIPTION
The controller needs permissions to interact with the CRDs that have been added over the past months. This PR is meant to fix that so that a fresh installation of Schemahero works as intended again.