### PR TITLE
Remove integration test matrix from CI workflows

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -67,125 +67,129 @@ jobs:
       - run: go mod tidy
       - run: make vet test
 
-  test-postgres:
-    runs-on: ubuntu-latest
-    needs: build
-    strategy:
-      fail-fast: false
-      matrix:
-        postgres_version: ["11.18", "12.13", "13.9", "14.6", "15.1"]
-    steps:
-      - uses: actions/checkout@v4.1.1
-      - name: Download kubectl-schemahero binary
-        uses: actions/download-artifact@v4.3.0
-        with:
-          name: kubectl-schemahero
-          path: bin/
-      - run: chmod +x bin/kubectl-schemahero
-      - run: make -C integration/tests/postgres ${{matrix.postgres_version}}
+  # Integration tests have been moved to plugin repositories
+  # These tests are disabled since all database engines are now plugins
+  # TODO: Remove these jobs completely after verifying plugin tests work
+  
+  # test-postgres:
+  #   runs-on: ubuntu-latest
+  #   needs: build
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       postgres_version: ["11.18", "12.13", "13.9", "14.6", "15.1"]
+  #   steps:
+  #     - uses: actions/checkout@v4.1.1
+  #     - name: Download kubectl-schemahero binary
+  #       uses: actions/download-artifact@v4.3.0
+  #       with:
+  #         name: kubectl-schemahero
+  #         path: bin/
+  #     - run: chmod +x bin/kubectl-schemahero
+  #     - run: make -C integration/tests/postgres ${{matrix.postgres_version}}
 
-  test-mysql:
-    runs-on: ubuntu-latest
-    needs: build
-    strategy:
-      fail-fast: false
-      matrix:
-        mysql_version: ["8.0.31", "8.4.5", "9.3.0"]
-    steps:
-      - uses: actions/checkout@v4.1.1
-      - name: Download kubectl-schemahero binary
-        uses: actions/download-artifact@v4.3.0
-        with:
-          name: kubectl-schemahero
-          path: bin/
-      - run: chmod +x bin/kubectl-schemahero
-      - run: make -C integration/tests/mysql ${{matrix.mysql_version}}
+  # test-mysql:
+  #   runs-on: ubuntu-latest
+  #   needs: build
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       mysql_version: ["8.0.31", "8.4.5", "9.3.0"]
+  #   steps:
+  #     - uses: actions/checkout@v4.1.1
+  #     - name: Download kubectl-schemahero binary
+  #       uses: actions/download-artifact@v4.3.0
+  #       with:
+  #         name: kubectl-schemahero
+  #         path: bin/
+  #     - run: chmod +x bin/kubectl-schemahero
+  #     - run: make -C integration/tests/mysql ${{matrix.mysql_version}}
 
-  test-cockroach:
-    runs-on: ubuntu-latest
-    needs: build
-    strategy:
-      fail-fast: false
-      matrix:
-        # "v19.2.12", "v20.2.19" are no longer supported
-        cockroachdb_version: ["v21.2.17", "v22.1.11"]
-    steps:
-      - uses: actions/checkout@v4.1.1
-      - name: Download kubectl-schemahero binary
-        uses: actions/download-artifact@v4.3.0
-        with:
-          name: kubectl-schemahero
-          path: bin/
-      - run: chmod +x bin/kubectl-schemahero
-      - run: make -C integration/tests/cockroach ${{matrix.cockroachdb_version}}
+  # test-cockroach:
+  #   runs-on: ubuntu-latest
+  #   needs: build
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       # "v19.2.12", "v20.2.19" are no longer supported
+  #       cockroachdb_version: ["v21.2.17", "v22.1.11"]
+  #   steps:
+  #     - uses: actions/checkout@v4.1.1
+  #     - name: Download kubectl-schemahero binary
+  #       uses: actions/download-artifact@v4.3.0
+  #       with:
+  #         name: kubectl-schemahero
+  #         path: bin/
+  #     - run: chmod +x bin/kubectl-schemahero
+  #     - run: make -C integration/tests/cockroach ${{matrix.cockroachdb_version}}
 
-  test-cassandra:
-    runs-on: ubuntu-latest
-    needs: build
-    strategy:
-      fail-fast: false
-      matrix:
-        cassandra_version: ["3.11.10"]
-    steps:
-      - uses: actions/checkout@v4.1.1
-      - name: Download kubectl-schemahero binary
-        uses: actions/download-artifact@v4.3.0
-        with:
-          name: kubectl-schemahero
-          path: bin/
-      - run: chmod +x bin/kubectl-schemahero
-      - run: make -C integration/tests/cassandra ${{matrix.cassandra_version}}
+  # test-cassandra:
+  #   runs-on: ubuntu-latest
+  #   needs: build
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       cassandra_version: ["3.11.10"]
+  #   steps:
+  #     - uses: actions/checkout@v4.1.1
+  #     - name: Download kubectl-schemahero binary
+  #       uses: actions/download-artifact@v4.3.0
+  #       with:
+  #         name: kubectl-schemahero
+  #         path: bin/
+  #     - run: chmod +x bin/kubectl-schemahero
+  #     - run: make -C integration/tests/cassandra ${{matrix.cassandra_version}}
 
-  test-sqlite:
-    runs-on: ubuntu-latest
-    needs: build
-    strategy:
-      fail-fast: false
-      matrix:
-        sqlite_version: ["3.39.3"]
-    steps:
-      - uses: actions/checkout@v4.1.1
-      - name: Download kubectl-schemahero binary
-        uses: actions/download-artifact@v4.3.0
-        with:
-          name: kubectl-schemahero
-          path: bin/
-      - run: chmod +x bin/kubectl-schemahero
-      - run: make -C integration/tests/sqlite ${{matrix.sqlite_version}}
+  # test-sqlite:
+  #   runs-on: ubuntu-latest
+  #   needs: build
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       sqlite_version: ["3.39.3"]
+  #   steps:
+  #     - uses: actions/checkout@v4.1.1
+  #     - name: Download kubectl-schemahero binary
+  #       uses: actions/download-artifact@v4.3.0
+  #       with:
+  #         name: kubectl-schemahero
+  #         path: bin/
+  #     - run: chmod +x bin/kubectl-schemahero
+  #     - run: make -C integration/tests/sqlite ${{matrix.sqlite_version}}
 
-  test-rqlite:
-    runs-on: ubuntu-latest
-    needs: build
-    strategy:
-      fail-fast: false
-      matrix:
-        rqlite_version: ["6.10.2", "7.6.1"]
-    steps:
-      - uses: actions/checkout@v4.1.1
-      - name: Download kubectl-schemahero binary
-        uses: actions/download-artifact@v4.3.0
-        with:
-          name: kubectl-schemahero
-          path: bin/
-      - run: chmod +x bin/kubectl-schemahero
-      - run: make -C integration/tests/rqlite ${{matrix.rqlite_version}}
+  # test-rqlite:
+  #   runs-on: ubuntu-latest
+  #   needs: build
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       rqlite_version: ["6.10.2", "7.6.1"]
+  #   steps:
+  #     - uses: actions/checkout@v4.1.1
+  #     - name: Download kubectl-schemahero binary
+  #       uses: actions/download-artifact@v4.3.0
+  #       with:
+  #         name: kubectl-schemahero
+  #         path: bin/
+  #     - run: chmod +x bin/kubectl-schemahero
+  #     - run: make -C integration/tests/rqlite ${{matrix.rqlite_version}}
 
-  test-timescaledb:
-    runs-on: ubuntu-latest
-    needs: build
-    strategy:
-      fail-fast: false
-      matrix:
-        timescaledb_version: ["2.9.3-pg14"]
-    steps:
-      - uses: actions/checkout@v4.1.1
-      - name: Download kubectl-schemahero binary
-        uses: actions/download-artifact@v4.3.0
-        with:
-          name: kubectl-schemahero
-          path: bin/
-      - run: chmod +x bin/kubectl-schemahero
-      - run: make -C integration/tests/timescaledb ${{matrix.timescaledb_version}}
+  # test-timescaledb:
+  #   runs-on: ubuntu-latest
+  #   needs: build
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       timescaledb_version: ["2.9.3-pg14"]
+  #   steps:
+  #     - uses: actions/checkout@v4.1.1
+  #     - name: Download kubectl-schemahero binary
+  #       uses: actions/download-artifact@v4.3.0
+  #       with:
+  #         name: kubectl-schemahero
+  #         path: bin/
+  #     - run: chmod +x bin/kubectl-schemahero
+  #     - run: make -C integration/tests/timescaledb ${{matrix.timescaledb_version}}
 
   test-fixtures:
     runs-on: ubuntu-latest
@@ -205,13 +209,14 @@ jobs:
     needs:
       - build
       - test
-      - test-postgres
-      - test-mysql
-      - test-cockroach
-      - test-cassandra
-      - test-sqlite
-      - test-rqlite
-      - test-timescaledb
+      # Database-specific tests removed - moved to plugin repositories
+      # - test-postgres
+      # - test-mysql
+      # - test-cockroach
+      # - test-cassandra
+      # - test-sqlite
+      # - test-rqlite
+      # - test-timescaledb
       - test-fixtures
     steps:
       - name: All tests passed

--- a/.github/workflows/tagged-release.yaml
+++ b/.github/workflows/tagged-release.yaml
@@ -36,129 +36,135 @@ jobs:
           name: kubectl-schemahero
           path: bin/kubectl-schemahero
 
-  test-postgres:
-    runs-on: ubuntu-latest
-    needs: build
-    strategy:
-      matrix:
-        postgres_version: ["11.18", "12.13", "13.9", "14.6", "15.1"]
-    steps:
-      - uses: actions/checkout@v4.1.1
-      - name: Download kubectl-schemahero binary
-        uses: actions/download-artifact@v4.3.0
-        with:
-          name: kubectl-schemahero
-          path: bin/
-      - run: chmod +x bin/kubectl-schemahero
-      - run: make -C integration/tests/postgres ${{matrix.postgres_version}}
+  # Integration tests have been moved to plugin repositories
+  # These tests are disabled since all database engines are now plugins
+  # TODO: Remove these jobs completely after verifying plugin tests work
+  
+  # test-postgres:
+  #   runs-on: ubuntu-latest
+  #   needs: build
+  #   strategy:
+  #     matrix:
+  #       postgres_version: ["11.18", "12.13", "13.9", "14.6", "15.1"]
+  #   steps:
+  #     - uses: actions/checkout@v4.1.1
+  #     - name: Download kubectl-schemahero binary
+  #       uses: actions/download-artifact@v4.3.0
+  #       with:
+  #         name: kubectl-schemahero
+  #         path: bin/
+  #     - run: chmod +x bin/kubectl-schemahero
+  #     - run: make -C integration/tests/postgres ${{matrix.postgres_version}}
 
-  test-mysql:
-    runs-on: ubuntu-latest
-    needs: build
-    strategy:
-      matrix:
-        mysql_version: ["8.0.31", "8.4.5", "9.3.0"]
-    steps:
-      - uses: actions/checkout@v4.1.1
-      - name: Download kubectl-schemahero binary
-        uses: actions/download-artifact@v4.3.0
-        with:
-          name: kubectl-schemahero
-          path: bin/
-      - run: chmod +x bin/kubectl-schemahero
-      - run: make -C integration/tests/mysql ${{matrix.mysql_version}}
+  # test-mysql:
+  #   runs-on: ubuntu-latest
+  #   needs: build
+  #   strategy:
+  #     matrix:
+  #       mysql_version: ["8.0.31", "8.4.5", "9.3.0"]
+  #   steps:
+  #     - uses: actions/checkout@v4.1.1
+  #     - name: Download kubectl-schemahero binary
+  #       uses: actions/download-artifact@v4.3.0
+  #       with:
+  #         name: kubectl-schemahero
+  #         path: bin/
+  #     - run: chmod +x bin/kubectl-schemahero
+  #     - run: make -C integration/tests/mysql ${{matrix.mysql_version}}
 
-  test-cockroach:
-    runs-on: ubuntu-latest
-    needs: build
-    strategy:
-      matrix:
-        # "v19.2.12", "v20.2.19" are no longer supported
-        cockroachdb_version: ["v21.2.17", "v22.1.11"]
-    steps:
-      - uses: actions/checkout@v4.1.1
-      - name: Download kubectl-schemahero binary
-        uses: actions/download-artifact@v4.3.0
-        with:
-          name: kubectl-schemahero
-          path: bin/
-      - run: chmod +x bin/kubectl-schemahero
-      - run: make -C integration/tests/cockroach ${{matrix.cockroachdb_version}}
+  # test-cockroach:
+  #   runs-on: ubuntu-latest
+  #   needs: build
+  #   strategy:
+  #     matrix:
+  #       # "v19.2.12", "v20.2.19" are no longer supported
+  #       cockroachdb_version: ["v21.2.17", "v22.1.11"]
+  #   steps:
+  #     - uses: actions/checkout@v4.1.1
+  #     - name: Download kubectl-schemahero binary
+  #       uses: actions/download-artifact@v4.3.0
+  #       with:
+  #         name: kubectl-schemahero
+  #         path: bin/
+  #     - run: chmod +x bin/kubectl-schemahero
+  #     - run: make -C integration/tests/cockroach ${{matrix.cockroachdb_version}}
 
-  test-cassandra:
-    runs-on: ubuntu-latest
-    needs: build
-    strategy:
-      matrix:
-        cassandra_version: ["3.11.10"]
-    steps:
-      - uses: actions/checkout@v4.1.1
-      - name: Download kubectl-schemahero binary
-        uses: actions/download-artifact@v4.3.0
-        with:
-          name: kubectl-schemahero
-          path: bin/
-      - run: chmod +x bin/kubectl-schemahero
-      - run: make -C integration/tests/cassandra ${{matrix.cassandra_version}}
+  # test-cassandra:
+  #   runs-on: ubuntu-latest
+  #   needs: build
+  #   strategy:
+  #     matrix:
+  #       cassandra_version: ["3.11.10"]
+  #   steps:
+  #     - uses: actions/checkout@v4.1.1
+  #     - name: Download kubectl-schemahero binary
+  #       uses: actions/download-artifact@v4.3.0
+  #       with:
+  #         name: kubectl-schemahero
+  #         path: bin/
+  #     - run: chmod +x bin/kubectl-schemahero
+  #     - run: make -C integration/tests/cassandra ${{matrix.cassandra_version}}
 
-  test-sqlite:
-    runs-on: ubuntu-latest
-    needs: build
-    strategy:
-      matrix:
-        sqlite_version: ["3.39.3"]
-    steps:
-      - uses: actions/checkout@v4.1.1
-      - name: Download kubectl-schemahero binary
-        uses: actions/download-artifact@v4.3.0
-        with:
-          name: kubectl-schemahero
-          path: bin/
-      - run: chmod +x bin/kubectl-schemahero
-      - run: make -C integration/tests/sqlite ${{matrix.sqlite_version}}
+  # test-sqlite:
+  #   runs-on: ubuntu-latest
+  #   needs: build
+  #   strategy:
+  #     matrix:
+  #       sqlite_version: ["3.39.3"]
+  #   steps:
+  #     - uses: actions/checkout@v4.1.1
+  #     - name: Download kubectl-schemahero binary
+  #       uses: actions/download-artifact@v4.3.0
+  #       with:
+  #         name: kubectl-schemahero
+  #         path: bin/
+  #     - run: chmod +x bin/kubectl-schemahero
+  #     - run: make -C integration/tests/sqlite ${{matrix.sqlite_version}}
 
-  test-rqlite:
-    runs-on: ubuntu-latest
-    needs: build
-    strategy:
-      matrix:
-        rqlite_version: ["6.10.2", "7.6.1"]
-    steps:
-      - uses: actions/checkout@v4.1.1
-      - name: Download kubectl-schemahero binary
-        uses: actions/download-artifact@v4.3.0
-        with:
-          name: kubectl-schemahero
-          path: bin/
-      - run: chmod +x bin/kubectl-schemahero
-      - run: make -C integration/tests/rqlite ${{matrix.rqlite_version}}
+  # test-rqlite:
+  #   runs-on: ubuntu-latest
+  #   needs: build
+  #   strategy:
+  #     matrix:
+  #       rqlite_version: ["6.10.2", "7.6.1"]
+  #   steps:
+  #     - uses: actions/checkout@v4.1.1
+  #     - name: Download kubectl-schemahero binary
+  #       uses: actions/download-artifact@v4.3.0
+  #       with:
+  #         name: kubectl-schemahero
+  #         path: bin/
+  #     - run: chmod +x bin/kubectl-schemahero
+  #     - run: make -C integration/tests/rqlite ${{matrix.rqlite_version}}
 
-  test-timescaledb:
-    runs-on: ubuntu-latest
-    needs: build
-    strategy:
-      matrix:
-        timescaledb_version: ["2.9.3-pg14"]
-    steps:
-      - uses: actions/checkout@v4.1.1
-      - name: Download kubectl-schemahero binary
-        uses: actions/download-artifact@v4.3.0
-        with:
-          name: kubectl-schemahero
-          path: bin/
-      - run: chmod +x bin/kubectl-schemahero
-      - run: make -C integration/tests/timescaledb ${{matrix.timescaledb_version}}
+  # test-timescaledb:
+  #   runs-on: ubuntu-latest
+  #   needs: build
+  #   strategy:
+  #     matrix:
+  #       timescaledb_version: ["2.9.3-pg14"]
+  #   steps:
+  #     - uses: actions/checkout@v4.1.1
+  #     - name: Download kubectl-schemahero binary
+  #       uses: actions/download-artifact@v4.3.0
+  #       with:
+  #         name: kubectl-schemahero
+  #         path: bin/
+  #     - run: chmod +x bin/kubectl-schemahero
+  #     - run: make -C integration/tests/timescaledb ${{matrix.timescaledb_version}}
 
   build-docker-manager:
     runs-on: ubuntu-latest
     needs:
-      - test-postgres
-      - test-mysql
-      - test-cockroach
-      - test-cassandra
-      - test-sqlite
-      - test-rqlite
-      - test-timescaledb
+      - build
+      # Database-specific tests removed - moved to plugin repositories
+      # - test-postgres
+      # - test-mysql
+      # - test-cockroach
+      # - test-cassandra
+      # - test-sqlite
+      # - test-rqlite
+      # - test-timescaledb
     outputs:
       digest: ${{ steps.release-manager.outputs.digest }}
     steps:
@@ -200,13 +206,15 @@ jobs:
   build-docker-schemahero:
     runs-on: ubuntu-latest
     needs:
-      - test-postgres
-      - test-mysql
-      - test-cockroach
-      - test-cassandra
-      - test-sqlite
-      - test-rqlite
-      - test-timescaledb
+      - build
+      # Database-specific tests removed - moved to plugin repositories
+      # - test-postgres
+      # - test-mysql
+      # - test-cockroach
+      # - test-cassandra
+      # - test-sqlite
+      # - test-rqlite
+      # - test-timescaledb
     outputs:
       digest: ${{ steps.release-schemahero.outputs.digest }}
     steps:
@@ -251,13 +259,15 @@ jobs:
   github-release-tarballs:
     runs-on: ubuntu-latest
     needs:
-      - test-postgres
-      - test-mysql
-      - test-cockroach
-      - test-cassandra
-      - test-sqlite
-      - test-rqlite
-      - test-timescaledb
+      - build
+      # Database-specific tests removed - moved to plugin repositories
+      # - test-postgres
+      # - test-mysql
+      # - test-cockroach
+      # - test-cassandra
+      # - test-sqlite
+      # - test-rqlite
+      # - test-timescaledb
     steps:
       - uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
## Summary

This PR removes the database-specific integration test matrices from the CI workflows since all database engines have been moved to plugins.

## Changes

- Commented out all database-specific test jobs (postgres, mysql, cockroach, cassandra, sqlite, rqlite, timescaledb)
- Updated job dependencies to skip the disabled tests
- Tests are kept commented for reference during the transition period

## Why?

With the plugin architecture fully implemented, each database engine is now a separate plugin with its own repository and test suite. Running these tests in the main repository is no longer necessary and adds unnecessary CI time.

## Next Steps

- Each plugin repository will maintain its own integration tests
- After verifying plugin tests work correctly, the commented code can be removed completely

🤖 Generated with [Claude Code](https://claude.ai/code)