### PR TITLE
fix: move checkout before setup-go in github-release-tarballs job

### DIFF
--- a/.github/workflows/tagged-release.yaml
+++ b/.github/workflows/tagged-release.yaml
@@ -322,6 +322,8 @@ jobs:
       - test-rqlite
       - test-timescaledb
     steps:
+      - uses: actions/checkout@v4.1.1
+
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
@@ -330,8 +332,6 @@ jobs:
         run: |
           echo "::set-output name=go-build::$(go env GOCACHE)"
           echo "::set-output name=go-mod::$(go env GOMODCACHE)"
-
-      - uses: actions/checkout@v4.1.1
 
       - uses: actions/cache@v4
         with:


### PR DESCRIPTION
## Summary
- Fixes CI failure in `github-release-tarballs` job where `actions/setup-go@v5` was trying to read `go.mod` before `actions/checkout@v4.1.1` had run
- Moved checkout step before setup-go step to ensure repository files are available

## Test plan
- [x] Verify workflow file syntax is correct
- [ ] Confirm CI passes on tagged releases

🤖 Generated with [Claude Code](https://claude.ai/code)