### PR TITLE
Support multiline strings in postgres

### DIFF
--- a/integration/tests/postgres/seed-with-many-rows/expect.sql
+++ b/integration/tests/postgres/seed-with-many-rows/expect.sql
@@ -2,4 +2,4 @@ create table "users" ("id" integer, "login" character varying (255), "name" char
 insert into users (id, login, name) values (1, 'test', 'test2') on conflict ("id") do update set (id, login, name) = (excluded.id, excluded.login, excluded.name);
 insert into users (id, login, name) values (2, 'other', 'test2') on conflict ("id") do update set (id, login, name) = (excluded.id, excluded.login, excluded.name);
 insert into users (id, login, name) values (3, 'yet', 'someone') on conflict ("id") do update set (id, login, name) = (excluded.id, excluded.login, excluded.name);
-insert into users (id, login, name) values (4, 'another', 'more') on conflict ("id") do update set (id, login, name) = (excluded.id, excluded.login, excluded.name);
+insert into users (id, login, name) values (4, 'another', E'key1:\n  quoted: "a yaml\n    file"\n  unquotes: |\n    line 1\n    \'line in quotes\'\n    line \\ with backslash\n    line N\n') on conflict ("id") do update set (id, login, name) = (excluded.id, excluded.login, excluded.name);

--- a/integration/tests/postgres/seed-with-many-rows/specs/users.yaml
+++ b/integration/tests/postgres/seed-with-many-rows/specs/users.yaml
@@ -54,4 +54,12 @@ seedData:
           str: another
       - column: name
         value:
-          str: more
+          str: |
+            key1:
+              quoted: "a yaml
+                file"
+              unquotes: |
+                line 1
+                'line in quotes'
+                line \ with backslash
+                line N


### PR DESCRIPTION
1. This adds E prefix to enable support for escaped strings.
2. The `apply` command also splits string on new lines. So "\n" bytes are replaced with \`\n\` sequence as a special case.

```
schemahero=# select * from users;
-[ RECORD 1 ]--------------------
id    | 1
login | test
name  | test2
-[ RECORD 2 ]--------------------
id    | 2
login | other
name  | test2
-[ RECORD 3 ]--------------------
id    | 3
login | yet
name  | someone
-[ RECORD 4 ]--------------------
id    | 4
login | another
name  | key1:                    +
      |   quoted: "a yaml        +
      |     file"                +
      |   unquotes: |            +
      |     line 1               +
      |     'line in quotes'     +
      |     line \ with backslash+
      |     line N               +
      | 
```