### PR TITLE
chore(deps): upgrade golang to 1.25.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ kind: bin/kubectl-schemahero manager
 .PHONY: controller-gen
 controller-gen:
 ifeq (, $(shell which controller-gen))
-	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.14.0
+	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.19.0
 CONTROLLER_GEN=$(shell go env GOPATH)/bin/controller-gen
 else
 CONTROLLER_GEN=$(shell which controller-gen)

--- a/config/crds/v1/databases.schemahero.io_databases.yaml
+++ b/config/crds/v1/databases.schemahero.io_databases.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: databases.databases.schemahero.io
 spec:
   group: databases.schemahero.io

--- a/config/crds/v1/schemas.schemahero.io_databaseextensions.yaml
+++ b/config/crds/v1/schemas.schemahero.io_databaseextensions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: databaseextensions.schemas.schemahero.io
 spec:
   group: schemas.schemahero.io

--- a/config/crds/v1/schemas.schemahero.io_datatypes.yaml
+++ b/config/crds/v1/schemas.schemahero.io_datatypes.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: datatypes.schemas.schemahero.io
 spec:
   group: schemas.schemahero.io

--- a/config/crds/v1/schemas.schemahero.io_functions.yaml
+++ b/config/crds/v1/schemas.schemahero.io_functions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: functions.schemas.schemahero.io
 spec:
   group: schemas.schemahero.io

--- a/config/crds/v1/schemas.schemahero.io_migrations.yaml
+++ b/config/crds/v1/schemas.schemahero.io_migrations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: migrations.schemas.schemahero.io
 spec:
   group: schemas.schemahero.io

--- a/config/crds/v1/schemas.schemahero.io_tables.yaml
+++ b/config/crds/v1/schemas.schemahero.io_tables.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: tables.schemas.schemahero.io
 spec:
   group: schemas.schemahero.io
@@ -268,6 +268,11 @@ spec:
                           required:
                           - events
                           type: object
+                          x-kubernetes-validations:
+                          - message: exactly one of the fields in [execute executeProcedure]
+                              must be set
+                            rule: '[has(self.execute),has(self.executeProcedure)].filter(x,x==true).size()
+                              == 1'
                         type: array
                       primaryKey:
                         items:
@@ -334,8 +339,18 @@ spec:
                           required:
                           - events
                           type: object
+                          x-kubernetes-validations:
+                          - message: exactly one of the fields in [execute executeProcedure]
+                              must be set
+                            rule: '[has(self.execute),has(self.executeProcedure)].filter(x,x==true).size()
+                              == 1'
                         type: array
                     type: object
+                    x-kubernetes-validations:
+                    - message: exactly one of the fields in [triggers json:triggers]
+                        must be set
+                      rule: '[has(self.triggers),has(self.json:triggers)].filter(x,x==true).size()
+                        == 1'
                   mysql:
                     properties:
                       collation:
@@ -556,6 +571,11 @@ spec:
                           required:
                           - events
                           type: object
+                          x-kubernetes-validations:
+                          - message: exactly one of the fields in [execute executeProcedure]
+                              must be set
+                            rule: '[has(self.execute),has(self.executeProcedure)].filter(x,x==true).size()
+                              == 1'
                         type: array
                       primaryKey:
                         items:
@@ -622,8 +642,18 @@ spec:
                           required:
                           - events
                           type: object
+                          x-kubernetes-validations:
+                          - message: exactly one of the fields in [execute executeProcedure]
+                              must be set
+                            rule: '[has(self.execute),has(self.executeProcedure)].filter(x,x==true).size()
+                              == 1'
                         type: array
                     type: object
+                    x-kubernetes-validations:
+                    - message: exactly one of the fields in [triggers json:triggers]
+                        must be set
+                      rule: '[has(self.triggers),has(self.json:triggers)].filter(x,x==true).size()
+                        == 1'
                   rqlite:
                     properties:
                       columns:
@@ -968,6 +998,11 @@ spec:
                           required:
                           - events
                           type: object
+                          x-kubernetes-validations:
+                          - message: exactly one of the fields in [execute executeProcedure]
+                              must be set
+                            rule: '[has(self.execute),has(self.executeProcedure)].filter(x,x==true).size()
+                              == 1'
                         type: array
                     type: object
                 type: object

--- a/config/crds/v1/schemas.schemahero.io_views.yaml
+++ b/config/crds/v1/schemas.schemahero.io_views.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: views.schemas.schemahero.io
 spec:
   group: schemas.schemahero.io

--- a/deploy/Dockerfile.multiarch
+++ b/deploy/Dockerfile.multiarch
@@ -1,4 +1,4 @@
-FROM golang:1.24 AS build
+FROM golang:1.25 AS build
 WORKDIR /code
 COPY . .
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/schemahero/schemahero
 
-toolchain go1.24.2
-
-go 1.24.0
+go 1.25.4
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.39.3

--- a/pkg/apis/schemas/v1alpha4/postgresql.go
+++ b/pkg/apis/schemas/v1alpha4/postgresql.go
@@ -74,7 +74,7 @@ type PostgresqlTableColumn struct {
 	Default     *string                           `json:"default,omitempty" yaml:"default,omitempty"`
 }
 
-// +kubebuilder:validation:ExactlyOneOf=triggers;json:triggers
+// +kubebuilder:validation:ExactlyOneOf=triggers;"json:triggers"
 type PostgresqlTableSchema struct {
 	Schema      string                       `json:"schema,omitempty" yaml:"schema,omitempty"`
 	PrimaryKey  []string                     `json:"primaryKey,omitempty" yaml:"primaryKey,omitempty"`

--- a/pkg/installer/assets/databases.schemahero.io_databases.yaml
+++ b/pkg/installer/assets/databases.schemahero.io_databases.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: databases.databases.schemahero.io
 spec:
   group: databases.schemahero.io

--- a/pkg/installer/assets/schemas.schemahero.io_databaseextensions.yaml
+++ b/pkg/installer/assets/schemas.schemahero.io_databaseextensions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: databaseextensions.schemas.schemahero.io
 spec:
   group: schemas.schemahero.io

--- a/pkg/installer/assets/schemas.schemahero.io_datatypes.yaml
+++ b/pkg/installer/assets/schemas.schemahero.io_datatypes.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: datatypes.schemas.schemahero.io
 spec:
   group: schemas.schemahero.io

--- a/pkg/installer/assets/schemas.schemahero.io_functions.yaml
+++ b/pkg/installer/assets/schemas.schemahero.io_functions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: functions.schemas.schemahero.io
 spec:
   group: schemas.schemahero.io

--- a/pkg/installer/assets/schemas.schemahero.io_migrations.yaml
+++ b/pkg/installer/assets/schemas.schemahero.io_migrations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: migrations.schemas.schemahero.io
 spec:
   group: schemas.schemahero.io

--- a/pkg/installer/assets/schemas.schemahero.io_tables.yaml
+++ b/pkg/installer/assets/schemas.schemahero.io_tables.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: tables.schemas.schemahero.io
 spec:
   group: schemas.schemahero.io
@@ -268,6 +268,11 @@ spec:
                           required:
                           - events
                           type: object
+                          x-kubernetes-validations:
+                          - message: exactly one of the fields in [execute executeProcedure]
+                              must be set
+                            rule: '[has(self.execute),has(self.executeProcedure)].filter(x,x==true).size()
+                              == 1'
                         type: array
                       primaryKey:
                         items:
@@ -334,8 +339,18 @@ spec:
                           required:
                           - events
                           type: object
+                          x-kubernetes-validations:
+                          - message: exactly one of the fields in [execute executeProcedure]
+                              must be set
+                            rule: '[has(self.execute),has(self.executeProcedure)].filter(x,x==true).size()
+                              == 1'
                         type: array
                     type: object
+                    x-kubernetes-validations:
+                    - message: exactly one of the fields in [triggers json:triggers]
+                        must be set
+                      rule: '[has(self.triggers),has(self.json:triggers)].filter(x,x==true).size()
+                        == 1'
                   mysql:
                     properties:
                       collation:
@@ -556,6 +571,11 @@ spec:
                           required:
                           - events
                           type: object
+                          x-kubernetes-validations:
+                          - message: exactly one of the fields in [execute executeProcedure]
+                              must be set
+                            rule: '[has(self.execute),has(self.executeProcedure)].filter(x,x==true).size()
+                              == 1'
                         type: array
                       primaryKey:
                         items:
@@ -622,8 +642,18 @@ spec:
                           required:
                           - events
                           type: object
+                          x-kubernetes-validations:
+                          - message: exactly one of the fields in [execute executeProcedure]
+                              must be set
+                            rule: '[has(self.execute),has(self.executeProcedure)].filter(x,x==true).size()
+                              == 1'
                         type: array
                     type: object
+                    x-kubernetes-validations:
+                    - message: exactly one of the fields in [triggers json:triggers]
+                        must be set
+                      rule: '[has(self.triggers),has(self.json:triggers)].filter(x,x==true).size()
+                        == 1'
                   rqlite:
                     properties:
                       columns:
@@ -968,6 +998,11 @@ spec:
                           required:
                           - events
                           type: object
+                          x-kubernetes-validations:
+                          - message: exactly one of the fields in [execute executeProcedure]
+                              must be set
+                            rule: '[has(self.execute),has(self.executeProcedure)].filter(x,x==true).size()
+                              == 1'
                         type: array
                     type: object
                 type: object

--- a/pkg/installer/assets/schemas.schemahero.io_views.yaml
+++ b/pkg/installer/assets/schemas.schemahero.io_views.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: views.schemas.schemahero.io
 spec:
   group: schemas.schemahero.io

--- a/plugins/cassandra/go.mod
+++ b/plugins/cassandra/go.mod
@@ -1,8 +1,6 @@
 module github.com/schemahero/schemahero/plugins/cassandra
 
-go 1.24.0
-
-toolchain go1.24.2
+go 1.25.4
 
 replace github.com/schemahero/schemahero => ../..
 

--- a/plugins/mysql/go.mod
+++ b/plugins/mysql/go.mod
@@ -1,8 +1,6 @@
 module github.com/schemahero/schemahero/plugins/mysql
 
-go 1.24.0
-
-toolchain go1.24.2
+go 1.25.4
 
 replace github.com/schemahero/schemahero => ../..
 

--- a/plugins/postgres/go.mod
+++ b/plugins/postgres/go.mod
@@ -1,8 +1,6 @@
 module github.com/schemahero/schemahero/plugins/postgres
 
-go 1.24.0
-
-toolchain go1.24.2
+go 1.25.4
 
 replace github.com/schemahero/schemahero => ../..
 

--- a/plugins/rqlite/go.mod
+++ b/plugins/rqlite/go.mod
@@ -1,8 +1,6 @@
 module github.com/schemahero/schemahero/plugins/rqlite
 
-go 1.24.0
-
-toolchain go1.24.2
+go 1.25.4
 
 replace github.com/schemahero/schemahero => ../..
 

--- a/plugins/sqlite/go.mod
+++ b/plugins/sqlite/go.mod
@@ -1,8 +1,6 @@
 module github.com/schemahero/schemahero/plugins/sqlite
 
-go 1.24.0
-
-toolchain go1.24.2
+go 1.25.4
 
 replace github.com/schemahero/schemahero => ../..
 

--- a/plugins/timescaledb/go.mod
+++ b/plugins/timescaledb/go.mod
@@ -1,8 +1,6 @@
 module github.com/schemahero/schemahero/plugins/timescaledb
 
-go 1.24.0
-
-toolchain go1.24.2
+go 1.25.4
 
 replace github.com/schemahero/schemahero => ../..
 


### PR DESCRIPTION
Resolves cves

High    CVE-2025-58188
High    CVE-2025-61725
High    CVE-2025-61723
High    CVE-2025-58187

Note: upgrading controller-gen was required to compile with 1.25