### PR TITLE
fix: cannot apply a table with seed data in the same file

### DIFF
--- a/integration/tests/postgres/Makefile
+++ b/integration/tests/postgres/Makefile
@@ -34,6 +34,7 @@ build-postgres-plugin:
 	make -C unique-constraint-add run
 	make -C unique-constraint-drop run
 	make -C basic-seed run
+	make -C seed-data-with-schema run
 	make -C seed-data-without-schema run
 	make -C seed-with-many-rows run
 	make -C two-column-pk run
@@ -61,6 +62,7 @@ build-postgres-plugin:
 	make -C unique-constraint-add run
 	make -C unique-constraint-drop run
 	make -C basic-seed run
+	make -C seed-data-with-schema run
 	make -C seed-data-without-schema run
 	make -C seed-with-many-rows run
 	make -C two-column-pk run
@@ -88,6 +90,7 @@ build-postgres-plugin:
 	make -C unique-constraint-add run
 	make -C unique-constraint-drop run
 	make -C basic-seed run
+	make -C seed-data-with-schema run
 	make -C seed-data-without-schema run
 	make -C seed-with-many-rows run
 	make -C two-column-pk run
@@ -115,6 +118,7 @@ build-postgres-plugin:
 	make -C unique-constraint-add run
 	make -C unique-constraint-drop run
 	make -C basic-seed run
+	make -C seed-data-with-schema run
 	make -C seed-data-without-schema run
 	make -C seed-with-many-rows run
 	make -C two-column-pk run
@@ -143,6 +147,7 @@ build-postgres-plugin:
 	make -C unique-constraint-add run
 	make -C unique-constraint-drop run
 	make -C basic-seed run
+	make -C seed-data-with-schema run
 	make -C seed-data-without-schema run
 	make -C seed-with-many-rows run
 	make -C two-column-pk run
@@ -153,6 +158,7 @@ build-postgres-plugin:
 seed: export PG_VERSION = 15.1
 seed: build-postgres-plugin
 	make -C basic-seed run
+	make -C seed-data-with-schema run
 	make -C seed-data-without-schema run
 	make -C seed-with-many-rows run
 

--- a/integration/tests/postgres/seed-data-with-schema/Dockerfile
+++ b/integration/tests/postgres/seed-data-with-schema/Dockerfile
@@ -1,0 +1,4 @@
+FROM postgres
+
+ENV POSTGRES_USER=schemahero
+ENV POSTGRES_DB=schemahero

--- a/integration/tests/postgres/seed-data-with-schema/Makefile
+++ b/integration/tests/postgres/seed-data-with-schema/Makefile
@@ -1,0 +1,4 @@
+include ../common.mk
+
+TEST_NAME := postgres-seed-data-with-schema
+SPEC_FILE := ./specs

--- a/integration/tests/postgres/seed-data-with-schema/expect.sql
+++ b/integration/tests/postgres/seed-data-with-schema/expect.sql
@@ -1,0 +1,2 @@
+create table "table1" ("id" integer, "col1" character varying (255) not null, "col2" timestamp, primary key ("id"));
+insert into table1 (id, col1, col2) values (1, 'seed-value', '2024-01-01T00:00:00Z') on conflict ("id") do update set (id, col1, col2) = (excluded.id, excluded.col1, excluded.col2);

--- a/integration/tests/postgres/seed-data-with-schema/specs/users.yaml
+++ b/integration/tests/postgres/seed-data-with-schema/specs/users.yaml
@@ -1,0 +1,27 @@
+database: schemahero
+name: table1
+requires: []
+schema:
+  postgres:
+    primaryKey: [id]
+    columns:
+      - name: id
+        type: integer
+      - name: col1
+        type: varchar(255)
+        constraints:
+          notNull: true
+      - name: col2
+        type: timestamp
+seedData:
+  rows:
+    - columns:
+      - column: id
+        value:
+          int: 1
+      - column: col1
+        value:
+          str: seed-value
+      - column: col2
+        value:
+          str: "2024-01-01T00:00:00Z"

--- a/pkg/controller/table/reconcile_table.go
+++ b/pkg/controller/table/reconcile_table.go
@@ -226,7 +226,7 @@ func (r *ReconcileTable) plan(ctx context.Context, databaseInstance *databasesv1
 
 	// plan the seed data
 	seedStatements := []string{}
-	if databaseInstance.Spec.DeploySeedData {
+	if databaseInstance.Spec.DeploySeedData && tableInstance.Spec.SeedData != nil && len(schemaStatements) == 0 {
 		stmts, err := db.PlanSyncSeedData(&tableInstance.Spec)
 		if err != nil {
 			return reconcile.Result{}, errors.Wrapf(err, "failed to plan seed for table %s", tableInstance.Name)


### PR DESCRIPTION
main had a bug (and no test).   if you tried to apply a table with seed data in the same file, it failed with "failed to plan seed" because it checked for the schema to exist first.  

fixed, added a test.  the test confirmed the bug

tables and seed data defined together still work because the driver’s PlanTableSchema already appends the seed inserts to the schema DDL, and our new guard simply skips the redundant “seed-only” planning pass when schema statements are present (validated by the new seed-data-with-schema integration test). Seed-only specs remain covered: when you ship a separate seed file (no schema), PlanSyncTableSpec falls straight through to PlanSyncSeedData, which is already exercised by the existing integration/tests/postgres/seed-data-without-schema scenario.