### PR TITLE
show help if a subcommand isn't found

### DIFF
--- a/pkg/cli/schemaherokubectlcli/approve.go
+++ b/pkg/cli/schemaherokubectlcli/approve.go
@@ -15,9 +15,6 @@ func ApproveCmd() *cobra.Command {
 		PreRun: func(cmd *cobra.Command, args []string) {
 			viper.BindPFlags(cmd.Flags())
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return nil
-		},
 	}
 
 	cmd.AddCommand(ApproveMigrationCmd())

--- a/pkg/cli/schemaherokubectlcli/describe.go
+++ b/pkg/cli/schemaherokubectlcli/describe.go
@@ -15,9 +15,6 @@ func DescribeCmd() *cobra.Command {
 		PreRun: func(cmd *cobra.Command, args []string) {
 			viper.BindPFlags(cmd.Flags())
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return nil
-		},
 	}
 
 	cmd.AddCommand(DescribeMigrationCmd())

--- a/pkg/cli/schemaherokubectlcli/get.go
+++ b/pkg/cli/schemaherokubectlcli/get.go
@@ -15,9 +15,6 @@ func GetCmd() *cobra.Command {
 		PreRun: func(cmd *cobra.Command, args []string) {
 			viper.BindPFlags(cmd.Flags())
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return nil
-		},
 	}
 
 	cmd.AddCommand(GetDatabasesCmd())

--- a/pkg/cli/schemaherokubectlcli/recalculate.go
+++ b/pkg/cli/schemaherokubectlcli/recalculate.go
@@ -15,9 +15,6 @@ func RecalculateCmd() *cobra.Command {
 		PreRun: func(cmd *cobra.Command, args []string) {
 			viper.BindPFlags(cmd.Flags())
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return nil
-		},
 	}
 
 	cmd.AddCommand(RecalculateMigrationCmd())

--- a/pkg/cli/schemaherokubectlcli/reject.go
+++ b/pkg/cli/schemaherokubectlcli/reject.go
@@ -15,9 +15,6 @@ func RejectCmd() *cobra.Command {
 		PreRun: func(cmd *cobra.Command, args []string) {
 			viper.BindPFlags(cmd.Flags())
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return nil
-		},
 	}
 
 	cmd.AddCommand(RejectMigrationCmd())


### PR DESCRIPTION
This way if you type 'kubectl schemahero describe migation blah' you get a usage message instead of just exiting 0