### PR TITLE
Update MySQL CI matrix to latest supported versions

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -89,7 +89,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        mysql_version: ["8.0.31", "8.4.5", "9.3.0"]
+        mysql_version: ["8.0.45", "8.4.8", "9.5.2"]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6

--- a/.github/workflows/tagged-release.yaml
+++ b/.github/workflows/tagged-release.yaml
@@ -280,7 +280,7 @@ jobs:
     if: always() && !cancelled()
     strategy:
       matrix:
-        mysql_version: ["8.0.31", "8.4.5", "9.3.0"]
+        mysql_version: ["8.0.45", "8.4.8", "9.5.2"]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6

--- a/integration/tests/mysql/Makefile
+++ b/integration/tests/mysql/Makefile
@@ -1,11 +1,10 @@
-
 SHELL := /bin/bash
 
 export IMAGE
 export GO111MODULE=on
 
 .PHONY: run
-run: build-mysql-plugin 8.0.31 8.4.5 9.3.0
+run: build-mysql-plugin 8.0.45 8.4.8 9.5.2
 
 .PHONY: build-mysql-plugin
 build-mysql-plugin:
@@ -13,11 +12,9 @@ build-mysql-plugin:
 	@mkdir -p $(HOME)/.schemahero/plugins
 	@cd ../../../plugins/mysql && go build -o $(HOME)/.schemahero/plugins/schemahero-mysql .
 
-
-
-.PHONY: 8.0.31
-8.0.31: export MYSQL_VERSION = 8.0.31
-8.0.31: build-mysql-plugin
+.PHONY: 8.0.45
+8.0.45: export MYSQL_VERSION = 8.0.45
+8.0.45: build-mysql-plugin
 	make -C json run
 	make -C not-null-with-default run
 	make -C seed-nullable-text run
@@ -54,9 +51,9 @@ build-mysql-plugin:
 	make -C primary-key-keep run
 	make -C unchanged-charset run
 
-.PHONY: 8.4.5
-8.4.5: export MYSQL_VERSION = 8.4.5
-8.4.5: build-mysql-plugin
+.PHONY: 8.4.8
+8.4.8: export MYSQL_VERSION = 8.4.8
+8.4.8: build-mysql-plugin
 	make -C json run
 	make -C not-null-with-default run
 	make -C seed-nullable-text run
@@ -93,9 +90,9 @@ build-mysql-plugin:
 	make -C primary-key-keep run
 	make -C unchanged-charset run
 
-.PHONY: 9.3.0
-9.3.0: export MYSQL_VERSION = 9.3.0
-9.3.0: build-mysql-plugin
+.PHONY: 9.5.2
+9.5.2: export MYSQL_VERSION = 9.5.2
+9.5.2: build-mysql-plugin
 	make -C json run
 	make -C not-null-with-default run
 	make -C seed-nullable-text run


### PR DESCRIPTION
## Summary

Update the MySQL version matrix in CI to use the latest patch releases and replace EOL versions.

## Changes

| Old | New | Notes |
|-----|-----|-------|
| 8.0.31 | 8.0.45 | Extended support ends April 2026 |
| 8.4.5 | 8.4.8 | LTS, supported until 2032 |
| 9.3.0 | 9.5.2 | 9.3 EOL July 2025, 9.5 is current Innovation release |

## Files Changed

- `.github/workflows/build-and-test.yaml` - updated matrix
- `.github/workflows/tagged-release.yaml` - updated matrix  
- `integration/tests/mysql/Makefile` - updated targets

Reference: https://endoflife.date/mysql