### PR TITLE
Update SQLite CI version to latest

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -174,7 +174,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sqlite_version: ["3.39.3"]
+        sqlite_version: ["3.51.2"]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6

--- a/.github/workflows/tagged-release.yaml
+++ b/.github/workflows/tagged-release.yaml
@@ -359,7 +359,7 @@ jobs:
     if: always() && !cancelled()
     strategy:
       matrix:
-        sqlite_version: ["3.39.3"]
+        sqlite_version: ["3.51.2"]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6

--- a/integration/tests/sqlite/Makefile
+++ b/integration/tests/sqlite/Makefile
@@ -5,7 +5,7 @@ export IMAGE
 export GO111MODULE=on
 
 .PHONY: run
-run: build-sqlite-plugin 3.39.3
+run: build-sqlite-plugin 3.51.2
 
 .PHONY: build-sqlite-plugin
 build-sqlite-plugin:
@@ -13,9 +13,9 @@ build-sqlite-plugin:
 	@mkdir -p $(HOME)/.schemahero/plugins
 	@cd ../../../plugins/sqlite && go build -o $(HOME)/.schemahero/plugins/schemahero-sqlite .
 
-.PHONY: 3.39.3
-3.39.3: export SQLITE_VERSION = 3.39.3
-3.39.3: build-sqlite-plugin
+.PHONY: 3.51.2
+3.51.2: export SQLITE_VERSION = 3.51.2
+3.51.2: build-sqlite-plugin
 	make -C basic-seed run
 	make -C column-add run
 	make -C column-alter run


### PR DESCRIPTION
## Summary

Update SQLite to the latest release.

| Old | New |
|-----|-----|
| 3.39.3 | 3.51.2 |

SQLite maintains long-term support and the latest version is always recommended.

Reference: https://endoflife.date/sqlite