### PR TITLE
Update TimescaleDB CI version to latest

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -230,7 +230,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        timescaledb_version: ["2.9.3-pg14"]
+        timescaledb_version: ["2.25.0-pg17"]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6

--- a/.github/workflows/tagged-release.yaml
+++ b/.github/workflows/tagged-release.yaml
@@ -411,7 +411,7 @@ jobs:
     if: always() && !cancelled()
     strategy:
       matrix:
-        timescaledb_version: ["2.9.3-pg14"]
+        timescaledb_version: ["2.25.0-pg17"]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6

--- a/integration/tests/timescaledb/Makefile
+++ b/integration/tests/timescaledb/Makefile
@@ -5,7 +5,7 @@ export IMAGE
 export GO111MODULE=on
 
 .PHONY: run
-run: build-timescaledb-plugin 2.9.3-pg14
+run: build-timescaledb-plugin 2.25.0-pg17
 
 .PHONY: build-timescaledb-plugin
 build-timescaledb-plugin:
@@ -13,9 +13,9 @@ build-timescaledb-plugin:
 	@mkdir -p $(HOME)/.schemahero/plugins
 	@cd ../../../plugins/timescaledb && go build -o $(HOME)/.schemahero/plugins/schemahero-timescaledb .
 
-.PHONY: 2.9.3-pg14
-2.9.3-pg14: export TIMESCALEDB_VERSION = 2.9.3-pg14
-2.9.3-pg14: build-timescaledb-plugin
+.PHONY: 2.25.0-pg17
+2.25.0-pg17: export TIMESCALEDB_VERSION = 2.25.0-pg17
+2.25.0-pg17: build-timescaledb-plugin
 	make -C create-materialized-view run
 	make -C drop-materialized-view run
 	make -C alter-column-timezone run
@@ -39,7 +39,7 @@ build-timescaledb-plugin:
 
 
 .PHONY: seed
-seed: export TIMESCALEDB_VERSION = 2.9.3-pg14
+seed: export TIMESCALEDB_VERSION = 2.25.0-pg17
 seed:
 	make -C basic-seed run
 	make -C seed-data-without-schema run


### PR DESCRIPTION
## Summary

Update TimescaleDB to the latest release with a current PostgreSQL version.

## Changes

| Old | New |
|-----|-----|
| 2.9.3-pg14 | 2.25.0-pg17 |

This updates both the TimescaleDB version (2.9.3 → 2.25.0) and the underlying PostgreSQL version (14 → 17) to current releases.