### PR TITLE
fix: omit status from install manager yaml

### DIFF
--- a/pkg/installer/manager.go
+++ b/pkg/installer/manager.go
@@ -14,6 +14,8 @@ import (
 	kuberneteserrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
@@ -151,8 +153,14 @@ func secret(namespace string) *corev1.Secret {
 
 func managerYAML(namespace string) ([]byte, error) {
 	s := json.NewYAMLSerializer(json.DefaultMetaFactory, scheme.Scheme, scheme.Scheme)
+	managerObject, err := runtime.DefaultUnstructuredConverter.ToUnstructured(manager(namespace))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to convert manager to unstructured")
+	}
+	delete(managerObject, "status")
+
 	var result bytes.Buffer
-	if err := s.Encode(manager(namespace), &result); err != nil {
+	if err := s.Encode(&unstructured.Unstructured{Object: managerObject}, &result); err != nil {
 		return nil, errors.Wrap(err, "failed to marshal manager")
 	}
 

--- a/pkg/installer/manager_test.go
+++ b/pkg/installer/manager_test.go
@@ -1,0 +1,22 @@
+package installer
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestManagerYAMLOmitsStatus(t *testing.T) {
+	got, err := managerYAML("schemahero-system")
+	if err != nil {
+		t.Fatalf("managerYAML() error = %v", err)
+	}
+
+	manifest := string(got)
+	if !strings.Contains(manifest, "kind: StatefulSet") {
+		t.Fatalf("managerYAML() should render a StatefulSet, got:\n%s", manifest)
+	}
+
+	if strings.Contains(manifest, "\nstatus:") {
+		t.Fatalf("managerYAML() should not render status, got:\n%s", manifest)
+	}
+}


### PR DESCRIPTION
Closes #667.

## Summary
- Remove the top-level StatefulSet `status` from generated manager install YAML.
- Preserve Kubernetes YAML serialization by converting the manager object to unstructured form and deleting `status` before encoding.
- Add a regression test that fails when `managerYAML` renders a `status` block.

## Validation
- `go test ./pkg/installer -run TestManagerYAMLOmitsStatus -count=1`
- `go test ./pkg/installer -count=1`
- `go test ./pkg/cli/schemaherokubectlcli -count=1`
- `go test ./pkg/installer ./pkg/cli/schemaherokubectlcli -count=1`
- `go vet ./pkg/installer ./pkg/cli/schemaherokubectlcli`
- `git diff --check`