### PR TITLE
improve no-network plugin download error messaging, add plugin download command

### DIFF
--- a/pkg/cli/schemaherokubectlcli/plugin.go
+++ b/pkg/cli/schemaherokubectlcli/plugin.go
@@ -1,0 +1,44 @@
+package schemaherokubectlcli
+
+import (
+	"fmt"
+
+	"github.com/schemahero/schemahero/pkg/database/plugin"
+	"github.com/spf13/cobra"
+)
+
+func PluginCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "plugin",
+		Short: "Manage SchemaHero database plugins",
+	}
+
+	cmd.AddCommand(PluginDownloadCmd())
+
+	return cmd
+}
+
+func PluginDownloadCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "download <database>",
+		Short:         "Download a SchemaHero database plugin",
+		Args:          cobra.ExactArgs(1),
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			pluginManager := plugin.GetGlobalPluginManager()
+			if pluginManager == nil {
+				pluginManager = plugin.InitializePluginSystem()
+			}
+
+			pluginPath, err := pluginManager.DownloadPlugin(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Downloaded SchemaHero %s plugin to %s\n", args[0], pluginPath)
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/pkg/cli/schemaherokubectlcli/plugin.go
+++ b/pkg/cli/schemaherokubectlcli/plugin.go
@@ -24,6 +24,7 @@ func PluginDownloadCmd() *cobra.Command {
 		Short:         "Download a SchemaHero database plugin",
 		Args:          cobra.ExactArgs(1),
 		SilenceErrors: true,
+		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			pluginManager := plugin.GetGlobalPluginManager()
 			if pluginManager == nil {

--- a/pkg/cli/schemaherokubectlcli/plugin_test.go
+++ b/pkg/cli/schemaherokubectlcli/plugin_test.go
@@ -1,0 +1,47 @@
+package schemaherokubectlcli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/schemahero/schemahero/pkg/database/plugin"
+)
+
+func TestPluginDownloadCmdUsesCachedPlugin(t *testing.T) {
+	plugin.ResetGlobalPluginSystem()
+	t.Cleanup(plugin.ResetGlobalPluginSystem)
+
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	pluginDir := filepath.Join(homeDir, ".schemahero", "plugins")
+	if err := os.MkdirAll(pluginDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	pluginPath := filepath.Join(pluginDir, "schemahero-postgres")
+	if err := os.WriteFile(pluginPath, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	cmd := PluginDownloadCmd()
+	cmd.SetArgs([]string{"postgres"})
+	cmd.SetOut(&out)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("expected plugin download command to use cached plugin: %v", err)
+	}
+
+	output := out.String()
+	if !strings.Contains(output, "Downloaded SchemaHero postgres plugin to ") {
+		t.Fatalf("unexpected output: %q", output)
+	}
+
+	if !strings.Contains(output, pluginPath) {
+		t.Fatalf("expected output to include cached plugin path %q, got %q", pluginPath, output)
+	}
+}

--- a/pkg/cli/schemaherokubectlcli/root.go
+++ b/pkg/cli/schemaherokubectlcli/root.go
@@ -13,9 +13,10 @@ import (
 
 func RootCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "schemahero",
-		Short: "SchemaHero is a cloud-native database schema management tool",
-		Long:  `...`,
+		Use:           "schemahero",
+		Short:         "SchemaHero is a cloud-native database schema management tool",
+		Long:          `...`,
+		SilenceErrors: true,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			viper.BindPFlags(cmd.Flags())
 		},
@@ -60,7 +61,10 @@ func InitAndExecute() {
 	}()
 
 	if err := RootCmd().Execute(); err != nil {
-		fmt.Println(err)
+		if message, ok := plugin.DownloadErrorMessage(err); ok {
+			fmt.Fprintf(os.Stderr, "%s\n\n", message)
+		}
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }

--- a/pkg/cli/schemaherokubectlcli/root.go
+++ b/pkg/cli/schemaherokubectlcli/root.go
@@ -39,6 +39,7 @@ func RootCmd() *cobra.Command {
 	cmd.AddCommand(RejectCmd())
 	cmd.AddCommand(GenerateCmd())
 	cmd.AddCommand(FixturesCmd())
+	cmd.AddCommand(PluginCmd())
 
 	cmd.AddCommand(PlanCmd())
 	cmd.AddCommand(ApplyCmd())

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -33,6 +33,14 @@ type Database struct {
 	pluginManager  *plugin.PluginManager
 }
 
+type specTypeFallbackError struct {
+	err error
+}
+
+func (e *specTypeFallbackError) Error() string {
+	return e.err.Error()
+}
+
 // SetPluginManager sets the plugin manager for this database instance.
 // The plugin manager is used to resolve database connections through plugins
 // before falling back to in-tree drivers.
@@ -242,6 +250,9 @@ func (d *Database) PlanSync(specContents []byte, specType string) ([]string, err
 	if err == nil {
 		return plan, nil
 	}
+	if _, ok := err.(*specTypeFallbackError); !ok {
+		return nil, err
+	}
 
 	logger.Debugf("failed to plan using GVK, falling back on spec type parameter: %s", err)
 
@@ -285,7 +296,7 @@ func (d *Database) planGVKSync(specContents []byte) ([]string, error) {
 
 	obj, gvk, err := decode(specContents, nil, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to decode spec")
+		return nil, &specTypeFallbackError{err: errors.Wrap(err, "failed to decode spec")}
 	}
 
 	if gvk.Group == "schemas.schemahero.io" && gvk.Version == "v1alpha4" && gvk.Kind == "Table" {
@@ -310,7 +321,7 @@ func (d *Database) planGVKSync(specContents []byte) ([]string, error) {
 		}
 		return plan, nil
 	} else {
-		return nil, errors.Errorf("unknown gvk %s", gvk)
+		return nil, &specTypeFallbackError{err: errors.Errorf("unknown gvk %s", gvk)}
 	}
 }
 

--- a/pkg/database/database_test.go
+++ b/pkg/database/database_test.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/schemahero/schemahero/pkg/database/types"
@@ -70,6 +71,41 @@ language PLpgSQL;`,
 
 			assert.Equal(t, test.wantStatements, gotStatements)
 		})
+	}
+}
+
+func TestPlanSyncGVKPlanningErrorDoesNotFallBackToSpecType(t *testing.T) {
+	db := &Database{Driver: "postgres"}
+	spec := []byte(`
+apiVersion: schemas.schemahero.io/v1alpha4
+kind: Table
+metadata:
+  name: embeddings
+spec:
+  database: postgres
+  name: embeddings
+  schema:
+    postgres:
+      primaryKey: [id]
+      columns:
+        - name: id
+          type: serial
+          constraints:
+            notNull: true
+`)
+
+	_, err := db.PlanSync(spec, "table")
+	if err == nil {
+		t.Fatal("expected planning error")
+	}
+
+	errString := err.Error()
+	if !strings.Contains(errString, "failed to plan table embeddings") {
+		t.Fatalf("expected GVK planning error, got %q", errString)
+	}
+
+	if strings.Contains(errString, "failed to plan table sync for embeddings") {
+		t.Fatalf("expected no fallback to spec-type planning, got %q", errString)
 	}
 }
 

--- a/pkg/database/plugin/downloader.go
+++ b/pkg/database/plugin/downloader.go
@@ -6,16 +6,22 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
+	"time"
 
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content/file"
 	"oras.land/oras-go/v2/registry/remote"
+	"oras.land/oras-go/v2/registry/remote/auth"
 )
+
+const pluginDownloadConnectionTimeout = 30 * time.Second
 
 // PluginDownloader handles downloading plugins from ORAS artifacts on Docker Hub
 type PluginDownloader struct {
@@ -153,6 +159,7 @@ func (d *PluginDownloader) downloadPluginOnce(ctx context.Context, driver string
 	if err != nil {
 		return fmt.Errorf("failed to create repository reference for %s: %w", repoURL, err)
 	}
+	repo.Client = newPluginDownloadClient()
 
 	// Use file store with higher size limit (100MB) for plugin artifacts
 	fs, err := file.NewWithFallbackLimit(cacheDir, 100*1024*1024) // 100MB limit
@@ -228,6 +235,26 @@ func (d *PluginDownloader) downloadPluginOnce(ctx context.Context, driver string
 	}
 
 	return nil
+}
+
+func newPluginDownloadClient() *auth.Client {
+	dialer := &net.Dialer{
+		Timeout: pluginDownloadConnectionTimeout,
+	}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.DialContext = dialer.DialContext
+	transport.TLSHandshakeTimeout = pluginDownloadConnectionTimeout
+	transport.ResponseHeaderTimeout = pluginDownloadConnectionTimeout
+
+	return &auth.Client{
+		Client: &http.Client{
+			Transport: transport,
+		},
+		Header: http.Header{
+			"User-Agent": {"schemahero"},
+		},
+		Cache: auth.DefaultCache,
+	}
 }
 
 // extractPlugin extracts a plugin binary from a tar.gz archive

--- a/pkg/database/plugin/downloader_test.go
+++ b/pkg/database/plugin/downloader_test.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -145,12 +146,26 @@ func TestPluginManager_DownloadPluginErrorMessage(t *testing.T) {
 	}
 
 	errString := err.Error()
-	if !strings.Contains(errString, "Failed to download SchemaHero postgres plugin. You can download this plugin ahead of time with 'schemahero plugin download postgres'") {
+	if !strings.Contains(errString, "Failed to download SchemaHero postgres plugin") {
 		t.Fatalf("expected SchemaHero plugin download error, got %q", errString)
+	}
+
+	if strings.Contains(errString, "You can download this plugin ahead of time") {
+		t.Fatalf("expected no remediation steps in Go error string, got %q", errString)
 	}
 
 	if !strings.Contains(errString, "context canceled") {
 		t.Fatalf("expected original Go error string, got %q", errString)
+	}
+
+	var downloadErr *DownloadError
+	if !errors.As(err, &downloadErr) {
+		t.Fatalf("expected DownloadError, got %T", err)
+	}
+
+	expectedMessage := "Failed to download SchemaHero postgres plugin. You can download this plugin ahead of time with 'schemahero plugin download postgres'"
+	if downloadErr.Message() != expectedMessage {
+		t.Fatalf("expected message %q, got %q", expectedMessage, downloadErr.Message())
 	}
 }
 

--- a/pkg/database/plugin/downloader_test.go
+++ b/pkg/database/plugin/downloader_test.go
@@ -145,7 +145,7 @@ func TestPluginManager_DownloadPluginErrorMessage(t *testing.T) {
 	}
 
 	errString := err.Error()
-	if !strings.Contains(errString, "failed to download SchemaHero postgres plugin") {
+	if !strings.Contains(errString, "Failed to download SchemaHero postgres plugin. You can download this plugin ahead of time with 'schemahero plugin download postgres'") {
 		t.Fatalf("expected SchemaHero plugin download error, got %q", errString)
 	}
 

--- a/pkg/database/plugin/downloader_test.go
+++ b/pkg/database/plugin/downloader_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -128,6 +129,28 @@ func TestPluginDownloader_CleanPluginCache(t *testing.T) {
 	// Verify it's gone
 	if _, err := os.Stat(pluginPath); !os.IsNotExist(err) {
 		t.Error("Plugin file should not exist after cleaning")
+	}
+}
+
+func TestPluginManager_DownloadPluginErrorMessage(t *testing.T) {
+	manager := NewPluginManager(NewPluginRegistry(), NewPluginLoader(t.TempDir()))
+	manager.downloader = NewPluginDownloader(t.TempDir())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := manager.DownloadPlugin(ctx, "postgres")
+	if err == nil {
+		t.Fatal("expected download error")
+	}
+
+	errString := err.Error()
+	if !strings.Contains(errString, "failed to download SchemaHero postgres plugin") {
+		t.Fatalf("expected SchemaHero plugin download error, got %q", errString)
+	}
+
+	if !strings.Contains(errString, "context canceled") {
+		t.Fatalf("expected original Go error string, got %q", errString)
 	}
 }
 

--- a/pkg/database/plugin/errors.go
+++ b/pkg/database/plugin/errors.go
@@ -1,0 +1,34 @@
+package plugin
+
+import (
+	"errors"
+	"fmt"
+)
+
+// DownloadError preserves the full download failure while exposing a short
+// user-facing message for CLI output.
+type DownloadError struct {
+	Plugin string
+	Err    error
+}
+
+func (e *DownloadError) Error() string {
+	return fmt.Sprintf("%s: %v", e.Message(), e.Err)
+}
+
+func (e *DownloadError) Unwrap() error {
+	return e.Err
+}
+
+func (e *DownloadError) Message() string {
+	return fmt.Sprintf("Failed to download SchemaHero %s plugin. You can download this plugin ahead of time with 'schemahero plugin download %s'", e.Plugin, e.Plugin)
+}
+
+func DownloadErrorMessage(err error) (string, bool) {
+	var downloadErr *DownloadError
+	if errors.As(err, &downloadErr) {
+		return downloadErr.Message(), true
+	}
+
+	return "", false
+}

--- a/pkg/database/plugin/errors.go
+++ b/pkg/database/plugin/errors.go
@@ -13,7 +13,7 @@ type DownloadError struct {
 }
 
 func (e *DownloadError) Error() string {
-	return fmt.Sprintf("%s: %v", e.Message(), e.Err)
+	return fmt.Sprintf("%s: %v", e.errorMessage(), e.Err)
 }
 
 func (e *DownloadError) Unwrap() error {
@@ -21,7 +21,11 @@ func (e *DownloadError) Unwrap() error {
 }
 
 func (e *DownloadError) Message() string {
-	return fmt.Sprintf("Failed to download SchemaHero %s plugin. You can download this plugin ahead of time with 'schemahero plugin download %s'", e.Plugin, e.Plugin)
+	return fmt.Sprintf("%s. You can download this plugin ahead of time with 'schemahero plugin download %s'", e.errorMessage(), e.Plugin)
+}
+
+func (e *DownloadError) errorMessage() string {
+	return fmt.Sprintf("Failed to download SchemaHero %s plugin", e.Plugin)
 }
 
 func DownloadErrorMessage(err error) (string, bool) {

--- a/pkg/database/plugin/manager.go
+++ b/pkg/database/plugin/manager.go
@@ -367,7 +367,10 @@ func (m *PluginManager) DownloadPlugin(ctx context.Context, engine string) (stri
 
 	pluginPath, err := m.downloader.DownloadPlugin(ctx, normalizedEngine, majorVersion)
 	if err != nil {
-		return "", fmt.Errorf("failed to download SchemaHero %s plugin: %w", normalizedEngine, err)
+		return "", &DownloadError{
+			Plugin: normalizedEngine,
+			Err:    err,
+		}
 	}
 
 	return pluginPath, nil

--- a/pkg/database/plugin/manager.go
+++ b/pkg/database/plugin/manager.go
@@ -337,8 +337,27 @@ func (m *PluginManager) RegisterPlugin(info *PluginInfo) error {
 }
 
 // downloadAndLoadPlugin attempts to download and load a plugin for the specified engine
-// from ORAS artifacts on Docker Hub using the naming convention schemahero/plugin-{engine}:{major}
 func (m *PluginManager) downloadAndLoadPlugin(ctx context.Context, engine string) (DatabasePlugin, error) {
+	// Download the plugin
+	pluginPath, err := m.DownloadPlugin(ctx, engine)
+	if err != nil {
+		return nil, err
+	}
+
+	normalizedEngine := m.normalizeEngineForDownload(engine)
+
+	// Load the downloaded plugin
+	return m.loadPluginFromPath(ctx, normalizedEngine, pluginPath)
+}
+
+// DownloadPlugin downloads the default SchemaHero plugin for the specified
+// engine from ORAS artifacts on Docker Hub using the naming convention schemahero/plugin-{engine}:{major}
+// and returns the local cached plugin path.
+func (m *PluginManager) DownloadPlugin(ctx context.Context, engine string) (string, error) {
+	if engine == "" {
+		return "", fmt.Errorf("database engine cannot be empty")
+	}
+
 	// Get the current major version for SchemaHero
 	// For now, we'll use "0" as the major version since we're in 0.x.y releases
 	majorVersion := m.getCurrentMajorVersion()
@@ -346,20 +365,12 @@ func (m *PluginManager) downloadAndLoadPlugin(ctx context.Context, engine string
 	// Normalize engine name - handle aliases
 	normalizedEngine := m.normalizeEngineForDownload(engine)
 
-	// Check if plugin is already cached
-	if m.downloader.IsPluginCached(normalizedEngine, majorVersion) {
-		pluginPath := m.downloader.GetCachedPluginPath(normalizedEngine, majorVersion)
-		return m.loadPluginFromPath(ctx, normalizedEngine, pluginPath)
-	}
-
-	// Download the plugin
 	pluginPath, err := m.downloader.DownloadPlugin(ctx, normalizedEngine, majorVersion)
 	if err != nil {
-		return nil, fmt.Errorf("failed to download plugin for engine '%s': %w", engine, err)
+		return "", fmt.Errorf("failed to download SchemaHero %s plugin: %w", normalizedEngine, err)
 	}
 
-	// Load the downloaded plugin
-	return m.loadPluginFromPath(ctx, normalizedEngine, pluginPath)
+	return pluginPath, nil
 }
 
 // loadPluginFromPath loads a plugin from a filesystem path and registers it


### PR DESCRIPTION
No-plugin airgap behavior improvements:
1. set a 30s time limit for connecting/ssl handshake/first bytes downloaded
2. give a human readable error message (in addition to the full go error string, instead of the go error string twice)

```
Failed to download SchemaHero postgres plugin. You can download this plugin ahead of time with 'schemahero plugin download postgres'

plan sync from file "/tmp/schemahero-test.yaml": failed to plan sync: failed to plan table embeddings: failed to get database connection: postgres driver requires plugin: failed to get plugin for engine 'postgres': Failed to download SchemaHero postgres plugin: failed to download plugin from docker.io/schemahero/plugin-postgres:0 (repo: docker.io/schemahero/plugin-postgres, tag: 0): failed to perform "FetchReference" on source: Get "https://registry-1.docker.io/v2/schemahero/plugin-postgres/manifests/0": dial tcp 18.233.78.24:443: i/o timeout
```

Plugin download command:
3. `schemahero plugin download postgres` will download the postgres plugin for later use without internet