### PR TITLE
feat: Add ENUM type support to MySQL plugin

### DIFF
--- a/plugins/mysql/lib/alter_test.go
+++ b/plugins/mysql/lib/alter_test.go
@@ -332,6 +332,135 @@ func Test_AlterColumnStatment(t *testing.T) {
 				"alter table `t` modify column `c` int (11) not null",
 			},
 		},
+		// enum alter tests
+		{
+			name:      "enum no change",
+			tableName: "t",
+			desiredColumns: []*schemasv1alpha4.MysqlTableColumn{
+				{
+					Name: "status",
+					Type: "enum('active','inactive')",
+				},
+			},
+			existingColumn: &types.Column{
+				Name:     "status",
+				DataType: "enum('active','inactive')",
+			},
+			expectedStatements: []string{},
+		},
+		{
+			name:      "enum change values",
+			tableName: "t",
+			desiredColumns: []*schemasv1alpha4.MysqlTableColumn{
+				{
+					Name: "status",
+					Type: "enum('active','inactive','pending')",
+					Constraints: &schemasv1alpha4.MysqlTableColumnConstraints{
+						NotNull: &trueValue,
+					},
+				},
+			},
+			existingColumn: &types.Column{
+				Name:     "status",
+				DataType: "enum('active','inactive')",
+			},
+			expectedStatements: []string{
+				"alter table `t` modify column `status` enum('active','inactive','pending') not null",
+			},
+		},
+		{
+			name:      "enum to varchar",
+			tableName: "t",
+			desiredColumns: []*schemasv1alpha4.MysqlTableColumn{
+				{
+					Name: "status",
+					Type: "varchar (255)",
+				},
+			},
+			existingColumn: &types.Column{
+				Name:     "status",
+				DataType: "enum('active','inactive')",
+			},
+			expectedStatements: []string{
+				"alter table `t` modify column `status` varchar (255)",
+			},
+		},
+		{
+			name:      "varchar to enum",
+			tableName: "t",
+			desiredColumns: []*schemasv1alpha4.MysqlTableColumn{
+				{
+					Name: "status",
+					Type: "enum('active','inactive')",
+				},
+			},
+			existingColumn: &types.Column{
+				Name:     "status",
+				DataType: "varchar (255)",
+			},
+			expectedStatements: []string{
+				"alter table `t` modify column `status` enum('active','inactive')",
+			},
+		},
+		{
+			name:      "enum drop column",
+			tableName: "t",
+			desiredColumns: []*schemasv1alpha4.MysqlTableColumn{
+				{
+					Name: "other",
+					Type: "integer",
+				},
+			},
+			existingColumn: &types.Column{
+				Name:     "status",
+				DataType: "enum('active','inactive')",
+			},
+			expectedStatements: []string{"alter table `t` drop column `status`"},
+		},
+		{
+			name:      "enum add not null",
+			tableName: "t",
+			desiredColumns: []*schemasv1alpha4.MysqlTableColumn{
+				{
+					Name: "status",
+					Type: "enum('active','inactive')",
+					Constraints: &schemasv1alpha4.MysqlTableColumnConstraints{
+						NotNull: &trueValue,
+					},
+				},
+			},
+			existingColumn: &types.Column{
+				Name:     "status",
+				DataType: "enum('active','inactive')",
+				Constraints: &types.ColumnConstraints{
+					NotNull: &falseValue,
+				},
+			},
+			expectedStatements: []string{"alter table `t` modify column `status` enum('active','inactive') not null"},
+		},
+		{
+			name:      "enum add not null with default",
+			tableName: "t",
+			desiredColumns: []*schemasv1alpha4.MysqlTableColumn{
+				{
+					Name: "status",
+					Type: "enum('active','inactive')",
+					Constraints: &schemasv1alpha4.MysqlTableColumnConstraints{
+						NotNull: &trueValue,
+					},
+					Default: func() *string { s := "active"; return &s }(),
+				},
+			},
+			existingColumn: &types.Column{
+				Name:     "status",
+				DataType: "enum('active','inactive')",
+			},
+			expectedStatements: []string{
+				"alter table `t` modify column `status` enum('active','inactive') default \"active\"",
+				"update `t` set `status`=\"active\" where `status` is null",
+				"alter table `t` modify column `status` enum('active','inactive') not null default \"active\"",
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/plugins/mysql/lib/column_test.go
+++ b/plugins/mysql/lib/column_test.go
@@ -68,15 +68,43 @@ func Test_mysqlColumnAsInsert(t *testing.T) {
 			expectedStatement: "`c` varchar (255) character set latin1 collate latin1_danish_ci not null default '11'",
 		},
 		{
-			name: "json field type",
+			name: "json",
 			column: &schemasv1alpha4.MysqlTableColumn{
-				Name: "obj",
+				Name: "j",
 				Type: "json",
+			},
+			expectedStatement: "`j` json",
+		},
+		{
+			name: "enum not null",
+			column: &schemasv1alpha4.MysqlTableColumn{
+				Name: "status",
+				Type: "enum('active','inactive','pending')",
 				Constraints: &schemasv1alpha4.MysqlTableColumnConstraints{
 					NotNull: &trueValue,
 				},
 			},
-			expectedStatement: "`obj` json not null",
+			expectedStatement: "`status` enum('active','inactive','pending') not null",
+		},
+		{
+			name: "enum with default",
+			column: &schemasv1alpha4.MysqlTableColumn{
+				Name: "status",
+				Type: "enum('active','inactive')",
+				Constraints: &schemasv1alpha4.MysqlTableColumnConstraints{
+					NotNull: &trueValue,
+				},
+				Default: func() *string { s := "active"; return &s }(),
+			},
+			expectedStatement: "`status` enum('active','inactive') not null default 'active'",
+		},
+		{
+			name: "enum nullable",
+			column: &schemasv1alpha4.MysqlTableColumn{
+				Name: "role",
+				Type: "enum('admin','user','guest')",
+			},
+			expectedStatement: "`role` enum('admin','user','guest')",
 		},
 	}
 
@@ -155,6 +183,28 @@ func Test_InsertColumnStatement(t *testing.T) {
 			},
 			expectedStatement: "alter table `t` add column `a` json not null",
 		},
+		{
+			name:      "add enum column",
+			tableName: "t",
+			desiredColumn: &schemasv1alpha4.MysqlTableColumn{
+				Name: "status",
+				Type: "enum('active','inactive')",
+				Constraints: &schemasv1alpha4.MysqlTableColumnConstraints{
+					NotNull: &trueValue,
+				},
+			},
+			expectedStatement: "alter table `t` add column `status` enum('active','inactive') not null",
+		},
+		{
+			name:      "add enum column with default",
+			tableName: "t",
+			desiredColumn: &schemasv1alpha4.MysqlTableColumn{
+				Name: "status",
+				Type: "enum('active','inactive')",
+				Default: func() *string { s := "active"; return &s }(),
+			},
+			expectedStatement: "alter table `t` add column `status` enum('active','inactive') default 'active'",
+		},
 	}
 
 	for _, test := range tests {
@@ -226,6 +276,28 @@ func Test_schemaColumnToMysqlColumn(t *testing.T) {
 				DataType: "json",
 			},
 		},
+		{
+			name: "enum('active','inactive')",
+			schemaColumn: &schemasv1alpha4.MysqlTableColumn{
+				Name: "status",
+				Type: "enum('active','inactive')",
+			},
+			expectedColumn: &types.Column{
+				Name:     "status",
+				DataType: "enum('active','inactive')",
+			},
+		},
+		{
+			name: "enum with spaces in type string",
+			schemaColumn: &schemasv1alpha4.MysqlTableColumn{
+				Name: "status",
+				Type: "enum('active', 'inactive', 'pending')",
+			},
+			expectedColumn: &types.Column{
+				Name:     "status",
+				DataType: "enum('active','inactive','pending')",
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -237,5 +309,4 @@ func Test_schemaColumnToMysqlColumn(t *testing.T) {
 			assert.Equal(t, test.expectedColumn, column)
 		})
 	}
-
 }

--- a/plugins/mysql/lib/create_test.go
+++ b/plugins/mysql/lib/create_test.go
@@ -164,6 +164,57 @@ func Test_CreateTableStatement(t *testing.T) {
 				"create table `test` (`id` int (11), primary key (`id`)) collate latin1_german1_ci",
 			},
 		},
+		{
+			name: "table with enum column",
+			tableSchema: &schemasv1alpha4.MysqlTableSchema{
+				PrimaryKey: []string{
+					"id",
+				},
+				Columns: []*schemasv1alpha4.MysqlTableColumn{
+					{
+						Name: "id",
+						Type: "integer",
+					},
+					{
+						Name: "status",
+						Type: "enum('active','inactive','pending')",
+						Constraints: &schemasv1alpha4.MysqlTableColumnConstraints{
+							NotNull: &trueValue,
+						},
+					},
+				},
+			},
+			tableName: "test_enum",
+			expectedStatements: []string{
+				"create table `test_enum` (`id` int (11), `status` enum('active','inactive','pending') not null, primary key (`id`))",
+			},
+		},
+		{
+			name: "table with enum column and default",
+			tableSchema: &schemasv1alpha4.MysqlTableSchema{
+				PrimaryKey: []string{
+					"id",
+				},
+				Columns: []*schemasv1alpha4.MysqlTableColumn{
+					{
+						Name: "id",
+						Type: "integer",
+					},
+					{
+						Name: "role",
+						Type: "enum('admin','user','guest')",
+						Constraints: &schemasv1alpha4.MysqlTableColumnConstraints{
+							NotNull: &trueValue,
+						},
+						Default: func() *string { s := "user"; return &s }(),
+					},
+				},
+			},
+			tableName: "test_enum_default",
+			expectedStatements: []string{
+				"create table `test_enum_default` (`id` int (11), `role` enum('admin','user','guest') not null default 'user', primary key (`id`))",
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/plugins/mysql/lib/parameterized.go
+++ b/plugins/mysql/lib/parameterized.go
@@ -307,6 +307,21 @@ func maybeParseParameterizedColumnType(requestedType string) (string, error) {
 		}
 	} else if strings.HasPrefix(requestedType, "json") {
 		columnType = "json"
+	} else if strings.HasPrefix(requestedType, "enum") {
+		r := regexp.MustCompile(`enum\s*\((.+)\)`)
+		matchGroups := r.FindStringSubmatch(requestedType)
+		if len(matchGroups) == 0 {
+			return "", fmt.Errorf("invalid enum type: at least one value required")
+		}
+
+		// Match single-quoted values; '' is MySQL's escaped single-quote inside a value
+		valueRegex := regexp.MustCompile(`'(?:[^']|'')*'`)
+		values := valueRegex.FindAllString(matchGroups[1], -1)
+		if len(values) == 0 {
+			return "", fmt.Errorf("invalid enum type: at least one value required")
+		}
+
+		columnType = fmt.Sprintf("enum(%s)", strings.Join(values, ","))
 	}
 
 	return columnType, nil

--- a/plugins/mysql/lib/parameterized_test.go
+++ b/plugins/mysql/lib/parameterized_test.go
@@ -192,6 +192,49 @@ func Test_maybeParseParameterizedColumnType(t *testing.T) {
 			expectedColumnType:  "",
 			expectedErrorSubstr: "invalid timestamp precision 7",
 		},
+		// enum tests
+		{
+			name:               "enum('active','inactive')",
+			requestedType:      "enum('active','inactive')",
+			expectedColumnType: "enum('active','inactive')",
+		},
+		{
+			name:               "enum('active', 'inactive', 'pending')",
+			requestedType:      "enum('active', 'inactive', 'pending')",
+			expectedColumnType: "enum('active','inactive','pending')",
+		},
+		{
+			name:               "enum ('a','b','c')",
+			requestedType:      "enum ('a','b','c')",
+			expectedColumnType: "enum('a','b','c')",
+		},
+		{
+			name:               "enum('single')",
+			requestedType:      "enum('single')",
+			expectedColumnType: "enum('single')",
+		},
+		{
+			name:               "enum('hello world','foo bar')",
+			requestedType:      "enum('hello world','foo bar')",
+			expectedColumnType: "enum('hello world','foo bar')",
+		},
+		{
+			name:               "enum with escaped single quote in value",
+			requestedType:      "enum('it''s','fine')",
+			expectedColumnType: "enum('it''s','fine')",
+		},
+		{
+			name:                "enum without values",
+			requestedType:       "enum",
+			expectedColumnType:  "",
+			expectedErrorSubstr: "invalid enum type: at least one value required",
+		},
+		{
+			name:                "enum() empty values",
+			requestedType:       "enum()",
+			expectedColumnType:  "",
+			expectedErrorSubstr: "invalid enum type: at least one value required",
+		},
 	}
 
 	for _, test := range tests {

--- a/plugins/mysql/lib/tables.go
+++ b/plugins/mysql/lib/tables.go
@@ -197,7 +197,7 @@ order by kcu.ORDINAL_POSITION`
 }
 
 func (m *MysqlConnection) GetTableSchema(tableName string) ([]*types.Column, error) {
-	query := `select COLUMN_NAME, COLUMN_DEFAULT, IS_NULLABLE, EXTRA, DATA_TYPE, CHARACTER_MAXIMUM_LENGTH, NUMERIC_PRECISION, NUMERIC_SCALE
+	query := `select COLUMN_NAME, COLUMN_DEFAULT, IS_NULLABLE, EXTRA, DATA_TYPE, CHARACTER_MAXIMUM_LENGTH, NUMERIC_PRECISION, NUMERIC_SCALE, COLUMN_TYPE
 from information_schema.COLUMNS
 where TABLE_NAME = ?
 and TABLE_SCHEMA = ?
@@ -221,8 +221,9 @@ order by ORDINAL_POSITION`
 		var columnDefault sql.NullString
 		var numericPrecision sql.NullInt64
 		var numericScale sql.NullInt64
+		var columnType string
 
-		if err := rows.Scan(&column.Name, &columnDefault, &isNullable, &extra, &column.DataType, &maxLength, &numericPrecision, &numericScale); err != nil {
+		if err := rows.Scan(&column.Name, &columnDefault, &isNullable, &extra, &column.DataType, &maxLength, &numericPrecision, &numericScale, &columnType); err != nil {
 			return nil, err
 		}
 
@@ -240,6 +241,14 @@ order by ORDINAL_POSITION`
 
 		if columnDefault.Valid {
 			column.ColumnDefault = &columnDefault.String
+		}
+
+		// For enum types, use the full COLUMN_TYPE (e.g. enum('a','b','c'))
+		// instead of constructing from DATA_TYPE + modifiers
+		if column.DataType == "enum" {
+			column.DataType = columnType
+			columns = append(columns, &column)
+			continue
 		}
 
 		// max length should not be written for all types


### PR DESCRIPTION
## Why?

Closes #25, closes #944

## What this does

Enable MySQL ENUM column type handling across all code paths:

- parameterized.go: parse and normalize enum('val1','val2',...) type strings with flexible whitespace, producing canonical format matching MySQL's information_schema.COLUMN_TYPE output
- tables.go: read COLUMN_TYPE in GetTableSchema so enum columns introspected from a live database preserve their value list instead of being mangled by the numeric max-length logic
- Comprehensive tests covering type parsing, column insert/alter DDL generation, create table statements, and error cases

## Notes
SET support to follow: #26