### PR TITLE
Track approved migration plan hashes

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -27,6 +27,8 @@ jobs:
             core:
               - 'pkg/**'
               - 'cmd/**'
+              - 'deploy/Dockerfile.multiarch'
+              - 'deploy/slack-app/**'
               - 'go.mod'
               - 'go.sum'
               - 'Makefile'
@@ -64,7 +66,7 @@ jobs:
           cache: true
           cache-dependency-path: ./go.sum
 
-      - run: make manifests bin/kubectl-schemahero manager
+      - run: make manifests bin/kubectl-schemahero manager bin/schemahero-slack-app
       - uses: actions/upload-artifact@v7.0.1
         with:
           name: kubectl-schemahero
@@ -73,6 +75,10 @@ jobs:
         with:
           name: manager
           path: bin/manager
+      - uses: actions/upload-artifact@v7.0.1
+        with:
+          name: schemahero-slack-app
+          path: bin/schemahero-slack-app
 
   test:
     runs-on: ubuntu-latest
@@ -100,6 +106,25 @@ jobs:
             exit 1
           }
       - run: make vet test
+
+  build-docker-slack-app:
+    runs-on: ubuntu-latest
+    needs: [changes]
+    if: >-
+      needs.changes.outputs.core == 'true'
+      || github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Build slack app image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: deploy/Dockerfile.multiarch
+          target: slack-app
+          push: false
+          tags: schemahero/slack-app:ci
 
   test-plugin-unit:
     runs-on: ubuntu-latest

--- a/.github/workflows/tagged-release.yaml
+++ b/.github/workflows/tagged-release.yaml
@@ -531,6 +531,58 @@ jobs:
           tags: ${{ steps.meta-schemahero.outputs.tags }}
           labels: ${{ steps.meta-schemahero.outputs.labels }}
 
+  build-docker-slack-app:
+    runs-on: ubuntu-latest
+    needs:
+      - test-postgres
+      - test-mysql
+      - test-cockroach
+      - test-cassandra
+      - test-sqlite
+      - test-rqlite
+      - test-timescaledb
+    if: always() && !cancelled()
+    outputs:
+      digest: ${{ steps.release-slack-app.outputs.digest }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - id: get_version
+        uses: battila7/get-version-action@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: schemaherodeploy
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Docker meta for slack app
+        id: meta-slack-app
+        uses: docker/metadata-action@v6
+        with:
+          images: index.docker.io/schemahero/slack-app
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable=${{ steps.get_version.outputs.prerelease == '' }}
+      - name: Build and push
+        id: release-slack-app
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: deploy/Dockerfile.multiarch
+          target: slack-app
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta-slack-app.outputs.tags }}
+          labels: ${{ steps.meta-slack-app.outputs.labels }}
+
   github-release-tarballs:
     runs-on: ubuntu-latest
     needs:

--- a/Makefile
+++ b/Makefile
@@ -190,6 +190,15 @@ bin/kubectl-schemahero: ## Build kubectl-schemahero binary
 		./cmd/kubectl-schemahero
 	@echo "built bin/kubectl-schemahero"
 
+.PHONY: bin/schemahero-slack-app
+bin/schemahero-slack-app: ## Build schemahero-slack-app binary
+	go build \
+	  -tags netgo -installsuffix netgo \
+		${LDFLAGS} \
+		-o bin/schemahero-slack-app \
+		./cmd/schemahero-slack-app
+	@echo "built bin/schemahero-slack-app"
+
 .PHONY: local
 local: bin/kubectl-schemahero manager
 	docker build -t schemahero/schemahero-manager -f ./Dockerfile.multiarch --target manager .
@@ -287,6 +296,10 @@ build-manager:
 .PHONY: build-schemahero
 build-schemahero:
 	CGO_ENABLED=0 GOOS=linux make bin/kubectl-schemahero
+
+.PHONY: build-slack-app
+build-slack-app:
+	CGO_ENABLED=0 GOOS=linux make bin/schemahero-slack-app
 
 .PHONY: cosign-sign
 cosign-sign:

--- a/cmd/schemahero-slack-app/main.go
+++ b/cmd/schemahero-slack-app/main.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+
+	schemasclientv1alpha4 "github.com/schemahero/schemahero/pkg/client/schemaheroclientset/typed/schemas/v1alpha4"
+	"github.com/schemahero/schemahero/pkg/config"
+	"github.com/schemahero/schemahero/pkg/slackapp"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+)
+
+func main() {
+	slackBotToken := os.Getenv("SLACK_BOT_TOKEN")
+	if slackBotToken == "" {
+		log.Fatal("SLACK_BOT_TOKEN is required")
+	}
+	slackChannelID := os.Getenv("SLACK_CHANNEL_ID")
+	if slackChannelID == "" {
+		log.Fatal("SLACK_CHANNEL_ID is required")
+	}
+	namespace := os.Getenv("SCHEMAHERO_NAMESPACE")
+	if namespace == "" {
+		namespace = "default"
+	}
+
+	cfg, err := config.GetRESTConfig()
+	if err != nil {
+		log.Fatal(err)
+	}
+	schemasClient, err := schemasclientv1alpha4.NewForConfig(cfg)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	poller := slackapp.NewPoller(
+		schemasClient,
+		slackapp.NewWebAPIClient(slackBotToken),
+		slackChannelID,
+		namespace,
+	)
+
+	if dispatcher, ok := slackapp.NewDepotDispatcherFromEnv(); ok {
+		poller.WithDispatcher(dispatcher)
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	log.Printf("starting schemahero slack app poller for namespace %s", namespace)
+	if err := poller.Run(ctx); err != nil && err != context.Canceled {
+		log.Fatal(err)
+	}
+}

--- a/config/crds/v1/schemas.schemahero.io_migrations.yaml
+++ b/config/crds/v1/schemas.schemahero.io_migrations.yaml
@@ -91,6 +91,13 @@ spec:
               approvedAt:
                 format: int64
                 type: integer
+              approvedBy:
+                description: ApprovedBy records the actor that approved this migration.
+                type: string
+              approvedPlanHash:
+                description: ApprovedPlanHash is the plan hash that was approved.
+                  It must match PlanHash before the controller will execute the migration.
+                type: string
               executedAt:
                 format: int64
                 type: integer
@@ -112,9 +119,16 @@ spec:
                   generated
                 format: int64
                 type: integer
+              planHash:
+                description: PlanHash is a stable SHA-256 hash of the exact generated
+                  DDL in this plan.
+                type: string
               rejectedAt:
                 format: int64
                 type: integer
+              rejectedBy:
+                description: RejectedBy records the actor that rejected this migration.
+                type: string
             type: object
         type: object
     served: true

--- a/config/crds/v1beta1/schemas.schemahero.io_migrations.yaml
+++ b/config/crds/v1beta1/schemas.schemahero.io_migrations.yaml
@@ -52,6 +52,13 @@ spec:
             approvedAt:
               format: int64
               type: integer
+            approvedBy:
+              description: ApprovedBy records the actor that approved this migration.
+              type: string
+            approvedPlanHash:
+              description: ApprovedPlanHash is the plan hash that was approved. It
+                must match PlanHash before the controller will execute the migration.
+              type: string
             executedAt:
               format: int64
               type: integer
@@ -65,9 +72,16 @@ spec:
                 generated
               format: int64
               type: integer
+            planHash:
+              description: PlanHash is a stable SHA-256 hash of the exact generated
+                DDL in this plan.
+              type: string
             rejectedAt:
               format: int64
               type: integer
+            rejectedBy:
+              description: RejectedBy records the actor that rejected this migration.
+              type: string
           type: object
       type: object
   version: v1alpha4

--- a/deploy/Dockerfile.multiarch
+++ b/deploy/Dockerfile.multiarch
@@ -8,6 +8,9 @@ RUN make build-manager
 FROM build AS build-schemahero
 RUN make build-schemahero
 
+FROM build AS build-slack-app
+RUN make build-slack-app
+
 FROM ubuntu:latest AS base
 RUN apt-get update -y && apt-get install -y ca-certificates
 
@@ -26,3 +29,11 @@ RUN useradd -c 'schemahero user' -m -d /home/schemahero -s /bin/bash -u 1001 sch
 USER schemahero
 ENV HOME=/home/schemahero
 ENTRYPOINT ["/schemahero"]
+
+# Slack app
+FROM base AS slack-app
+COPY --from=build-slack-app /code/bin/schemahero-slack-app /schemahero-slack-app
+RUN useradd -c 'schemahero slack app user' -m -d /home/schemahero-slack-app -s /bin/bash -u 1001 schemahero-slack-app
+USER schemahero-slack-app
+ENV HOME=/home/schemahero-slack-app
+ENTRYPOINT ["/schemahero-slack-app"]

--- a/deploy/slack-app/deployment.yaml
+++ b/deploy/slack-app/deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: schemahero-slack-app
+  namespace: schemahero-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: schemahero-slack-app
+  template:
+    metadata:
+      labels:
+        app: schemahero-slack-app
+    spec:
+      serviceAccountName: schemahero-slack-app
+      containers:
+        - name: schemahero-slack-app
+          image: schemahero/slack-app:latest
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: SLACK_BOT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: schemahero-slack-app
+                  key: slack-bot-token
+            - name: SLACK_CHANNEL_ID
+              valueFrom:
+                secretKeyRef:
+                  name: schemahero-slack-app
+                  key: slack-channel-id
+            - name: SCHEMAHERO_NAMESPACE
+              value: default
+            - name: DEPOT_CI_DISPATCH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: schemahero-slack-app
+                  key: depot-ci-dispatch-token
+                  optional: true

--- a/deploy/slack-app/kustomization.yaml
+++ b/deploy/slack-app/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - rbac.yaml
+  - deployment.yaml

--- a/deploy/slack-app/rbac.yaml
+++ b/deploy/slack-app/rbac.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: schemahero-slack-app
+  namespace: schemahero-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: schemahero-slack-app
+rules:
+  - apiGroups:
+      - schemas.schemahero.io
+    resources:
+      - migrations
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: schemahero-slack-app
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: schemahero-slack-app
+subjects:
+  - kind: ServiceAccount
+    name: schemahero-slack-app
+    namespace: schemahero-system

--- a/pkg/apis/schemas/v1alpha4/migration_types.go
+++ b/pkg/apis/schemas/v1alpha4/migration_types.go
@@ -17,6 +17,9 @@ limitations under the License.
 package v1alpha4
 
 import (
+	"crypto/sha256"
+	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -64,6 +67,19 @@ type MigrationStatus struct {
 	ApprovedAt int64 `json:"approvedAt,omitempty"`
 	RejectedAt int64 `json:"rejectedAt,omitempty"`
 	ExecutedAt int64 `json:"executedAt,omitempty"`
+
+	// PlanHash is a stable SHA-256 hash of the exact generated DDL in this plan.
+	PlanHash string `json:"planHash,omitempty"`
+
+	// ApprovedPlanHash is the plan hash that was approved. It must match PlanHash
+	// before the controller will execute the migration.
+	ApprovedPlanHash string `json:"approvedPlanHash,omitempty"`
+
+	// ApprovedBy records the actor that approved this migration.
+	ApprovedBy string `json:"approvedBy,omitempty"`
+
+	// RejectedBy records the actor that rejected this migration.
+	RejectedBy string `json:"rejectedBy,omitempty"`
 }
 
 // +genclient
@@ -95,4 +111,8 @@ type MigrationList struct {
 
 func init() {
 	SchemeBuilder.Register(&Migration{}, &MigrationList{})
+}
+
+func PlanHashForDDL(generatedDDL string) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(generatedDDL)))
 }

--- a/pkg/cli/schemaherokubectlcli/approve_migration.go
+++ b/pkg/cli/schemaherokubectlcli/approve_migration.go
@@ -3,6 +3,7 @@ package schemaherokubectlcli
 import (
 	"context"
 	"fmt"
+	"os/user"
 	"time"
 
 	"github.com/pkg/errors"
@@ -80,13 +81,34 @@ func ApproveMigrationCmd() *cobra.Command {
 					return errors.Errorf("migration %q is not in the planned phase (current phase: %s)", migrationName, migration.Status.Phase)
 				}
 
+				planHash := migration.Status.PlanHash
+				if planHash == "" {
+					planHash = v1alpha4.PlanHashForDDL(migration.Spec.GeneratedDDL)
+					migration.Status.PlanHash = planHash
+				}
+
+				expectedPlanHash := v.GetString("plan-hash")
+				if expectedPlanHash != "" && expectedPlanHash != planHash {
+					return errors.Errorf("migration %q plan hash changed: expected %s, current %s", migrationName, expectedPlanHash, planHash)
+				}
+
+				actor := v.GetString("actor")
+				if actor == "" {
+					currentUser, err := user.Current()
+					if err == nil {
+						actor = currentUser.Username
+					}
+				}
+
 				migration.Status.ApprovedAt = time.Now().Unix()
+				migration.Status.ApprovedPlanHash = planHash
+				migration.Status.ApprovedBy = actor
 				migration.Status.Phase = v1alpha4.Approved
 				if _, err := schemasClient.Migrations(namespaceName).Update(ctx, migration, metav1.UpdateOptions{}); err != nil {
 					return err
 				}
 
-				fmt.Printf("Migration %s approved\n", migrationName)
+				fmt.Printf("Migration %s approved for plan %s\n", migrationName, planHash)
 				return nil
 			}
 
@@ -96,6 +118,8 @@ func ApproveMigrationCmd() *cobra.Command {
 	}
 
 	cmd.Flags().Bool("all-namespaces", false, "If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.")
+	cmd.Flags().String("plan-hash", "", "Expected migration plan hash to approve")
+	cmd.Flags().String("actor", "", "Actor approving the migration")
 
 	return cmd
 }

--- a/pkg/cli/schemaherokubectlcli/describe_migration.go
+++ b/pkg/cli/schemaherokubectlcli/describe_migration.go
@@ -90,14 +90,28 @@ func DescribeMigrationCmd() *cobra.Command {
 
 				// Display status information
 				fmt.Printf("\nStatus: %s\n", foundMigration.Status.Phase)
+				planHash := foundMigration.Status.PlanHash
+				if planHash == "" {
+					planHash = schemasv1alpha4.PlanHashForDDL(foundMigration.Spec.GeneratedDDL)
+				}
+				fmt.Printf("Plan hash: %s\n", planHash)
 				if foundMigration.Status.ApprovedAt > 0 {
 					fmt.Printf("Approved at: %s\n", time.Unix(foundMigration.Status.ApprovedAt, 0).Format(time.RFC3339))
+				}
+				if foundMigration.Status.ApprovedBy != "" {
+					fmt.Printf("Approved by: %s\n", foundMigration.Status.ApprovedBy)
+				}
+				if foundMigration.Status.ApprovedPlanHash != "" {
+					fmt.Printf("Approved plan hash: %s\n", foundMigration.Status.ApprovedPlanHash)
 				}
 				if foundMigration.Status.ExecutedAt > 0 {
 					fmt.Printf("Applied at: %s\n", time.Unix(foundMigration.Status.ExecutedAt, 0).Format(time.RFC3339))
 				}
 				if foundMigration.Status.RejectedAt > 0 {
 					fmt.Printf("Rejected at: %s\n", time.Unix(foundMigration.Status.RejectedAt, 0).Format(time.RFC3339))
+				}
+				if foundMigration.Status.RejectedBy != "" {
+					fmt.Printf("Rejected by: %s\n", foundMigration.Status.RejectedBy)
 				}
 
 				// Only show approval/action commands for migrations that haven't been approved or applied

--- a/pkg/cli/schemaherokubectlcli/reject_migration.go
+++ b/pkg/cli/schemaherokubectlcli/reject_migration.go
@@ -3,6 +3,7 @@ package schemaherokubectlcli
 import (
 	"context"
 	"fmt"
+	"os/user"
 	"time"
 
 	"github.com/pkg/errors"
@@ -77,13 +78,33 @@ func RejectMigrationCmd() *cobra.Command {
 				}
 
 				if migration.Status.Phase == v1alpha4.Planned {
+					planHash := migration.Status.PlanHash
+					if planHash == "" {
+						planHash = v1alpha4.PlanHashForDDL(migration.Spec.GeneratedDDL)
+						migration.Status.PlanHash = planHash
+					}
+
+					expectedPlanHash := v.GetString("plan-hash")
+					if expectedPlanHash != "" && expectedPlanHash != planHash {
+						return errors.Errorf("migration %q plan hash changed: expected %s, current %s", migrationName, expectedPlanHash, planHash)
+					}
+
+					actor := v.GetString("actor")
+					if actor == "" {
+						currentUser, err := user.Current()
+						if err == nil {
+							actor = currentUser.Username
+						}
+					}
+
 					migration.Status.RejectedAt = time.Now().Unix()
+					migration.Status.RejectedBy = actor
 					migration.Status.Phase = v1alpha4.Rejected
 					if _, err := schemasClient.Migrations(namespaceName).Update(ctx, migration, metav1.UpdateOptions{}); err != nil {
 						return err
 					}
 
-					fmt.Printf("Migration %s rejected\n", migrationName)
+					fmt.Printf("Migration %s rejected for plan %s\n", migrationName, planHash)
 					return nil
 				} else {
 					fmt.Printf("Migration %s already %s\n", migrationName, migration.Status.Phase)
@@ -96,6 +117,8 @@ func RejectMigrationCmd() *cobra.Command {
 	}
 
 	cmd.Flags().Bool("all-namespaces", false, "If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.")
+	cmd.Flags().String("plan-hash", "", "Expected migration plan hash to reject")
+	cmd.Flags().String("actor", "", "Actor rejecting the migration")
 
 	return cmd
 }

--- a/pkg/controller/migration/reconcile_migration.go
+++ b/pkg/controller/migration/reconcile_migration.go
@@ -55,12 +55,12 @@ func (r *ReconcileMigration) reconcileMigration(ctx context.Context, migration *
 	// update the status to applied
 	migration.Status.ExecutedAt = time.Now().Unix()
 	migration.Status.Phase = schemasv1alpha4.Executed
-	err = r.Update(context.Background(), migration)
+	err = r.Update(ctx, migration)
 
 	if err != nil {
 		if kuberneteserrors.IsConflict(err) {
 			updatedMigration := &schemasv1alpha4.Migration{}
-			err := r.Get(context.Background(), types.NamespacedName{
+			err := r.Get(ctx, types.NamespacedName{
 				Name:      migration.Name,
 				Namespace: migration.Namespace,
 			}, updatedMigration)
@@ -69,8 +69,8 @@ func (r *ReconcileMigration) reconcileMigration(ctx context.Context, migration *
 			}
 
 			updatedMigration.Status.ExecutedAt = time.Now().Unix()
-			migration.Status.Phase = schemasv1alpha4.Executed
-			if err := r.Update(context.Background(), updatedMigration); err != nil {
+			updatedMigration.Status.Phase = schemasv1alpha4.Executed
+			if err := r.Update(ctx, updatedMigration); err != nil {
 				return reconcile.Result{}, errors.Wrap(err, "failed to update")
 			}
 		} else {

--- a/pkg/controller/migration/reconcile_migration.go
+++ b/pkg/controller/migration/reconcile_migration.go
@@ -82,10 +82,17 @@ func (r *ReconcileMigration) reconcileMigration(ctx context.Context, migration *
 }
 
 func shouldApplyMigration(migration *schemasv1alpha4.Migration) bool {
-	if migration.Status.ApprovedAt > 0 && migration.Status.ExecutedAt == 0 {
+	if migration.Status.ApprovedAt > 0 && migration.Status.ExecutedAt == 0 && approvedPlanHashMatches(migration) {
 		return true
 	}
 	return false
+}
+
+func approvedPlanHashMatches(migration *schemasv1alpha4.Migration) bool {
+	if migration.Status.PlanHash == "" {
+		return true
+	}
+	return migration.Status.ApprovedPlanHash == migration.Status.PlanHash
 }
 
 func getDatabaseFromMigration(ctx context.Context, migration *schemasv1alpha4.Migration) (*databasesv1alpha4.Database, error) {

--- a/pkg/controller/migration/reconcile_migration_test.go
+++ b/pkg/controller/migration/reconcile_migration_test.go
@@ -107,6 +107,30 @@ func Test_shouldApplyMigration(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "approved matching plan hash, should apply",
+			migration: &schemasv1alpha4.Migration{
+				Status: schemasv1alpha4.MigrationStatus{
+					ApprovedAt:       time.Now().Unix(),
+					ExecutedAt:       0,
+					PlanHash:         "current-plan",
+					ApprovedPlanHash: "current-plan",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "approved stale plan hash, should not apply",
+			migration: &schemasv1alpha4.Migration{
+				Status: schemasv1alpha4.MigrationStatus{
+					ApprovedAt:       time.Now().Unix(),
+					ExecutedAt:       0,
+					PlanHash:         "current-plan",
+					ApprovedPlanHash: "old-plan",
+				},
+			},
+			want: false,
+		},
+		{
 			name: "approved and executed, should not aply",
 			migration: &schemasv1alpha4.Migration{
 				Status: schemasv1alpha4.MigrationStatus{

--- a/pkg/controller/table/batch.go
+++ b/pkg/controller/table/batch.go
@@ -263,12 +263,14 @@ func (r *ReconcileTable) planBatch(ctx context.Context, databaseInstance *databa
 		},
 		Status: schemasv1alpha4.MigrationStatus{
 			PlannedAt: time.Now().Unix(),
+			PlanHash:  schemasv1alpha4.PlanHashForDDL(generatedDDL),
 			Phase:     schemasv1alpha4.Planned,
 		},
 	}
 
 	if databaseInstance.Spec.ImmediateDeploy {
 		migration.Status.ApprovedAt = time.Now().Unix()
+		migration.Status.ApprovedPlanHash = migration.Status.PlanHash
 		migration.Status.Phase = schemasv1alpha4.Planned
 	}
 

--- a/pkg/controller/table/reconcile_table.go
+++ b/pkg/controller/table/reconcile_table.go
@@ -329,12 +329,14 @@ func (r *ReconcileTable) plan(ctx context.Context, databaseInstance *databasesv1
 		},
 		Status: schemasv1alpha4.MigrationStatus{
 			PlannedAt: time.Now().Unix(),
+			PlanHash:  schemasv1alpha4.PlanHashForDDL(generatedDDL),
 			Phase:     schemasv1alpha4.Planned,
 		},
 	}
 
 	if databaseInstance.Spec.ImmediateDeploy {
 		migration.Status.ApprovedAt = time.Now().Unix()
+		migration.Status.ApprovedPlanHash = migration.Status.PlanHash
 		migration.Status.Phase = schemasv1alpha4.Planned
 	}
 

--- a/pkg/controller/view/reconcile_view.go
+++ b/pkg/controller/view/reconcile_view.go
@@ -216,12 +216,14 @@ func (r *ReconcileView) plan(ctx context.Context, databaseInstance *databasesv1a
 		},
 		Status: schemasv1alpha4.MigrationStatus{
 			PlannedAt: time.Now().Unix(),
+			PlanHash:  schemasv1alpha4.PlanHashForDDL(generatedDDL),
 			Phase:     schemasv1alpha4.Planned,
 		},
 	}
 
 	if databaseInstance.Spec.ImmediateDeploy {
 		migration.Status.ApprovedAt = time.Now().Unix()
+		migration.Status.ApprovedPlanHash = migration.Status.PlanHash
 		migration.Status.Phase = schemasv1alpha4.Planned
 	}
 

--- a/pkg/installer/assets/schemas.schemahero.io_migrations.yaml
+++ b/pkg/installer/assets/schemas.schemahero.io_migrations.yaml
@@ -91,6 +91,13 @@ spec:
               approvedAt:
                 format: int64
                 type: integer
+              approvedBy:
+                description: ApprovedBy records the actor that approved this migration.
+                type: string
+              approvedPlanHash:
+                description: ApprovedPlanHash is the plan hash that was approved.
+                  It must match PlanHash before the controller will execute the migration.
+                type: string
               executedAt:
                 format: int64
                 type: integer
@@ -112,9 +119,16 @@ spec:
                   generated
                 format: int64
                 type: integer
+              planHash:
+                description: PlanHash is a stable SHA-256 hash of the exact generated
+                  DDL in this plan.
+                type: string
               rejectedAt:
                 format: int64
                 type: integer
+              rejectedBy:
+                description: RejectedBy records the actor that rejected this migration.
+                type: string
             type: object
         type: object
     served: true

--- a/pkg/installer/assets/v1/schemas.schemahero.io_migrations.yaml
+++ b/pkg/installer/assets/v1/schemas.schemahero.io_migrations.yaml
@@ -76,6 +76,13 @@ spec:
               approvedAt:
                 format: int64
                 type: integer
+              approvedBy:
+                description: ApprovedBy records the actor that approved this migration.
+                type: string
+              approvedPlanHash:
+                description: ApprovedPlanHash is the plan hash that was approved.
+                  It must match PlanHash before the controller will execute the migration.
+                type: string
               executedAt:
                 format: int64
                 type: integer
@@ -97,9 +104,16 @@ spec:
                   generated
                 format: int64
                 type: integer
+              planHash:
+                description: PlanHash is a stable SHA-256 hash of the exact generated
+                  DDL in this plan.
+                type: string
               rejectedAt:
                 format: int64
                 type: integer
+              rejectedBy:
+                description: RejectedBy records the actor that rejected this migration.
+                type: string
             type: object
         type: object
     served: true

--- a/pkg/slackapp/dispatcher.go
+++ b/pkg/slackapp/dispatcher.go
@@ -18,7 +18,6 @@ const (
 	DefaultDispatchPollInterval = 10 * time.Second
 	DefaultDispatchTimeout      = 30 * time.Minute
 	defaultDepotBinary          = "depot"
-	defaultDepotRepo            = "replicatedhq/vandoor"
 	productionReleaseTagNeedle  = `release_tag="${PRODUCTION_RELEASE_TAG:-${{ inputs.tag || github.ref_name }}}"`
 	productionReleaseSHANeedle  = `release_sha="${PRODUCTION_RELEASE_SHA:-${{ inputs.sha || github.sha }}}"`
 	productionPreviousSHANeedle = `previous_sha="${PRODUCTION_PREVIOUS_SHA:-${{ inputs.previous-sha }}}"`
@@ -50,13 +49,9 @@ type DepotDispatcher struct {
 func NewDepotDispatcherFromEnv() (*DepotDispatcher, bool) {
 	token := os.Getenv("DEPOT_CI_DISPATCH_TOKEN")
 	workflowTemplatePath := os.Getenv("DEPOT_WORKFLOW_TEMPLATE_PATH")
-	if token == "" || workflowTemplatePath == "" {
-		return nil, false
-	}
-
 	repo := os.Getenv("DEPOT_REPO")
-	if repo == "" {
-		repo = defaultDepotRepo
+	if token == "" || workflowTemplatePath == "" || repo == "" {
+		return nil, false
 	}
 
 	depotBinary := os.Getenv("DEPOT_BINARY")
@@ -79,6 +74,9 @@ func (d *DepotDispatcher) Dispatch(ctx context.Context, release Release) error {
 	if d.WorkflowTemplatePath == "" {
 		return errors.New("depot workflow template path is required")
 	}
+	if d.Repo == "" {
+		return errors.New("depot repo is required")
+	}
 
 	renderedWorkflow, err := renderWorkflowTemplate(d.WorkflowTemplatePath, release)
 	if err != nil {
@@ -90,14 +88,9 @@ func (d *DepotDispatcher) Dispatch(ctx context.Context, release Release) error {
 	if depotBinary == "" {
 		depotBinary = defaultDepotBinary
 	}
-	repo := d.Repo
-	if repo == "" {
-		repo = defaultDepotRepo
-	}
-
 	cmd := exec.CommandContext(ctx, depotBinary,
 		"ci", "run",
-		"--repo", repo,
+		"--repo", d.Repo,
 		"--workflow", renderedWorkflow,
 		"--token", d.Token,
 	)

--- a/pkg/slackapp/dispatcher.go
+++ b/pkg/slackapp/dispatcher.go
@@ -1,0 +1,144 @@
+package slackapp
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	ReleaseTagAnnotation        = "replicated.com/release-tag"
+	ReleaseSHAAnnotation        = "replicated.com/release-sha"
+	PreviousSHAAnnotation       = "replicated.com/previous-sha"
+	PreviousTagNameAnnotation   = "replicated.com/previous-tag-name"
+	DefaultDispatchPollInterval = 10 * time.Second
+	DefaultDispatchTimeout      = 30 * time.Minute
+	defaultDepotBinary          = "depot"
+	defaultDepotRepo            = "replicatedhq/vandoor"
+	productionReleaseTagNeedle  = `release_tag="${PRODUCTION_RELEASE_TAG:-${{ inputs.tag || github.ref_name }}}"`
+	productionReleaseSHANeedle  = `release_sha="${PRODUCTION_RELEASE_SHA:-${{ inputs.sha || github.sha }}}"`
+	productionPreviousSHANeedle = `previous_sha="${PRODUCTION_PREVIOUS_SHA:-${{ inputs.previous-sha }}}"`
+	productionPreviousTagNeedle = `previous_tag_name="${PRODUCTION_PREVIOUS_TAG_NAME:-${{ inputs.previous-tag-name }}}"`
+)
+
+type Release struct {
+	Tag             string
+	SHA             string
+	PreviousSHA     string
+	PreviousTagName string
+}
+
+func (r Release) DispatchKey() string {
+	return r.Tag + ":" + r.SHA
+}
+
+type Dispatcher interface {
+	Dispatch(ctx context.Context, release Release) error
+}
+
+type DepotDispatcher struct {
+	Token                string
+	Repo                 string
+	WorkflowTemplatePath string
+	DepotBinary          string
+}
+
+func NewDepotDispatcherFromEnv() (*DepotDispatcher, bool) {
+	token := os.Getenv("DEPOT_CI_DISPATCH_TOKEN")
+	workflowTemplatePath := os.Getenv("DEPOT_WORKFLOW_TEMPLATE_PATH")
+	if token == "" || workflowTemplatePath == "" {
+		return nil, false
+	}
+
+	repo := os.Getenv("DEPOT_REPO")
+	if repo == "" {
+		repo = defaultDepotRepo
+	}
+
+	depotBinary := os.Getenv("DEPOT_BINARY")
+	if depotBinary == "" {
+		depotBinary = defaultDepotBinary
+	}
+
+	return &DepotDispatcher{
+		Token:                token,
+		Repo:                 repo,
+		WorkflowTemplatePath: workflowTemplatePath,
+		DepotBinary:          depotBinary,
+	}, true
+}
+
+func (d *DepotDispatcher) Dispatch(ctx context.Context, release Release) error {
+	if d.Token == "" {
+		return errors.New("depot token is required")
+	}
+	if d.WorkflowTemplatePath == "" {
+		return errors.New("depot workflow template path is required")
+	}
+
+	renderedWorkflow, err := renderWorkflowTemplate(d.WorkflowTemplatePath, release)
+	if err != nil {
+		return err
+	}
+	defer os.Remove(renderedWorkflow)
+
+	depotBinary := d.DepotBinary
+	if depotBinary == "" {
+		depotBinary = defaultDepotBinary
+	}
+	repo := d.Repo
+	if repo == "" {
+		repo = defaultDepotRepo
+	}
+
+	cmd := exec.CommandContext(ctx, depotBinary,
+		"ci", "run",
+		"--repo", repo,
+		"--workflow", renderedWorkflow,
+		"--token", d.Token,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return errors.Wrapf(err, "failed to dispatch depot workflow: %s", string(out))
+	}
+	return nil
+}
+
+func renderWorkflowTemplate(templatePath string, release Release) (string, error) {
+	workflowBytes, err := os.ReadFile(templatePath)
+	if err != nil {
+		return "", err
+	}
+
+	workflow := string(workflowBytes)
+	replacements := map[string]string{
+		productionReleaseTagNeedle:  `release_tag="` + release.Tag + `"`,
+		productionReleaseSHANeedle:  `release_sha="` + release.SHA + `"`,
+		productionPreviousSHANeedle: `previous_sha="` + release.PreviousSHA + `"`,
+		productionPreviousTagNeedle: `previous_tag_name="` + release.PreviousTagName + `"`,
+	}
+
+	for needle, replacement := range replacements {
+		if !strings.Contains(workflow, needle) {
+			return "", errors.Errorf("workflow template does not contain expected marker: %s", needle)
+		}
+		workflow = strings.ReplaceAll(workflow, needle, replacement)
+	}
+
+	rendered, err := os.CreateTemp("", "schemahero-production-continuation-*.yml")
+	if err != nil {
+		return "", err
+	}
+	defer rendered.Close()
+
+	if _, err := rendered.WriteString(workflow); err != nil {
+		os.Remove(rendered.Name())
+		return "", err
+	}
+
+	return rendered.Name(), nil
+}

--- a/pkg/slackapp/dispatcher_test.go
+++ b/pkg/slackapp/dispatcher_test.go
@@ -1,0 +1,40 @@
+package slackapp
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderWorkflowTemplate(t *testing.T) {
+	template := strings.Join([]string{
+		`release_tag="${PRODUCTION_RELEASE_TAG:-${{ inputs.tag || github.ref_name }}}"`,
+		`release_sha="${PRODUCTION_RELEASE_SHA:-${{ inputs.sha || github.sha }}}"`,
+		`previous_sha="${PRODUCTION_PREVIOUS_SHA:-${{ inputs.previous-sha }}}"`,
+		`previous_tag_name="${PRODUCTION_PREVIOUS_TAG_NAME:-${{ inputs.previous-tag-name }}}"`,
+	}, "\n")
+	templateFile, err := os.CreateTemp("", "workflow-template-*.yml")
+	require.NoError(t, err)
+	defer os.Remove(templateFile.Name())
+	_, err = templateFile.WriteString(template)
+	require.NoError(t, err)
+	require.NoError(t, templateFile.Close())
+
+	renderedPath, err := renderWorkflowTemplate(templateFile.Name(), Release{
+		Tag:             "v2026.06.10-0",
+		SHA:             "release-sha",
+		PreviousSHA:     "previous-sha",
+		PreviousTagName: "v2026.06.09-0",
+	})
+	require.NoError(t, err)
+	defer os.Remove(renderedPath)
+
+	rendered, err := os.ReadFile(renderedPath)
+	require.NoError(t, err)
+	require.Contains(t, string(rendered), `release_tag="v2026.06.10-0"`)
+	require.Contains(t, string(rendered), `release_sha="release-sha"`)
+	require.Contains(t, string(rendered), `previous_sha="previous-sha"`)
+	require.Contains(t, string(rendered), `previous_tag_name="v2026.06.09-0"`)
+}

--- a/pkg/slackapp/dispatcher_test.go
+++ b/pkg/slackapp/dispatcher_test.go
@@ -38,3 +38,25 @@ func TestRenderWorkflowTemplate(t *testing.T) {
 	require.Contains(t, string(rendered), `previous_sha="previous-sha"`)
 	require.Contains(t, string(rendered), `previous_tag_name="v2026.06.09-0"`)
 }
+
+func TestNewDepotDispatcherFromEnvRequiresRepo(t *testing.T) {
+	t.Setenv("DEPOT_CI_DISPATCH_TOKEN", "token")
+	t.Setenv("DEPOT_WORKFLOW_TEMPLATE_PATH", "/tmp/workflow.yml")
+	t.Setenv("DEPOT_REPO", "")
+
+	dispatcher, ok := NewDepotDispatcherFromEnv()
+
+	require.False(t, ok)
+	require.Nil(t, dispatcher)
+}
+
+func TestNewDepotDispatcherFromEnvUsesConfiguredRepo(t *testing.T) {
+	t.Setenv("DEPOT_CI_DISPATCH_TOKEN", "token")
+	t.Setenv("DEPOT_WORKFLOW_TEMPLATE_PATH", "/tmp/workflow.yml")
+	t.Setenv("DEPOT_REPO", "example/repo")
+
+	dispatcher, ok := NewDepotDispatcherFromEnv()
+
+	require.True(t, ok)
+	require.Equal(t, "example/repo", dispatcher.Repo)
+}

--- a/pkg/slackapp/poller.go
+++ b/pkg/slackapp/poller.go
@@ -1,0 +1,382 @@
+package slackapp
+
+import (
+	"context"
+	stderrors "errors"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	schemasv1alpha4 "github.com/schemahero/schemahero/pkg/apis/schemas/v1alpha4"
+	schemasclientv1alpha4 "github.com/schemahero/schemahero/pkg/client/schemaheroclientset/typed/schemas/v1alpha4"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	SlackChannelAnnotation     = "replicated.com/slack-channel"
+	SlackMessageTSAnnotation   = "replicated.com/slack-message-ts"
+	SlackInvalidReactionUsers  = "replicated.com/slack-invalid-reaction-users"
+	SlackApprovalReplyUser     = "replicated.com/slack-approval-reply-user"
+	SlackRejectionReplyUser    = "replicated.com/slack-rejection-reply-user"
+	ApproveReaction            = "white_check_mark"
+	DenyReaction               = "x"
+	DefaultPollInterval        = 15 * time.Second
+	DefaultPendingPollInterval = 5 * time.Second
+)
+
+type Poller struct {
+	schemasClient   schemasclientv1alpha4.SchemasV1alpha4Interface
+	slackClient     SlackClient
+	dispatcher      Dispatcher
+	channel         string
+	namespace       string
+	pollInterval    time.Duration
+	pendingInterval time.Duration
+	dispatchTimeout time.Duration
+	dispatched      map[string]bool
+	now             func() time.Time
+}
+
+type syncResult struct {
+	pending    bool
+	retryAfter time.Duration
+}
+
+func NewPoller(schemasClient schemasclientv1alpha4.SchemasV1alpha4Interface, slackClient SlackClient, channel string, namespace string) *Poller {
+	return &Poller{
+		schemasClient:   schemasClient,
+		slackClient:     slackClient,
+		channel:         channel,
+		namespace:       namespace,
+		pollInterval:    DefaultPollInterval,
+		pendingInterval: DefaultPendingPollInterval,
+		dispatchTimeout: DefaultDispatchTimeout,
+		dispatched:      map[string]bool{},
+		now:             time.Now,
+	}
+}
+
+func (p *Poller) WithDispatcher(dispatcher Dispatcher) *Poller {
+	p.dispatcher = dispatcher
+	return p
+}
+
+func (p *Poller) Run(ctx context.Context) error {
+	if p.channel == "" {
+		return errors.New("slack channel is required")
+	}
+	if p.pollInterval == 0 {
+		p.pollInterval = DefaultPollInterval
+	}
+	if p.pendingInterval == 0 {
+		p.pendingInterval = DefaultPendingPollInterval
+	}
+
+	for {
+		interval := p.syncAndLog(ctx)
+		timer := time.NewTimer(interval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func (p *Poller) syncAndLog(ctx context.Context) time.Duration {
+	result, err := p.sync(ctx)
+	if err != nil {
+		log.Printf("schemahero slack app sync failed: %v", err)
+		if result.retryAfter > 0 {
+			return result.retryAfter
+		}
+	}
+	if result.pending {
+		return p.pendingInterval
+	}
+	return p.pollInterval
+}
+
+func (p *Poller) Sync(ctx context.Context) error {
+	_, err := p.sync(ctx)
+	return err
+}
+
+func (p *Poller) sync(ctx context.Context) (syncResult, error) {
+	result := syncResult{}
+	migrations, err := p.schemasClient.Migrations(p.namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return result, err
+	}
+
+	for i := range migrations.Items {
+		migration := &migrations.Items[i]
+		if migration.Status.Phase != schemasv1alpha4.Planned {
+			continue
+		}
+		result.pending = true
+
+		if err := p.ensureApprovalMessage(ctx, migration); err != nil {
+			result.retryAfter = retryAfter(err)
+			return result, err
+		}
+		if err := p.handleReactions(ctx, migration); err != nil {
+			result.retryAfter = retryAfter(err)
+			return result, err
+		}
+	}
+
+	return result, nil
+}
+
+func retryAfter(err error) time.Duration {
+	var rateLimitErr *RateLimitError
+	if stderrors.As(err, &rateLimitErr) {
+		return rateLimitErr.RetryAfter
+	}
+	return 0
+}
+
+func (p *Poller) ensureApprovalMessage(ctx context.Context, migration *schemasv1alpha4.Migration) error {
+	annotations := migration.GetAnnotations()
+	if annotations[SlackMessageTSAnnotation] != "" {
+		return nil
+	}
+
+	planHash := migration.Status.PlanHash
+	if planHash == "" {
+		planHash = schemasv1alpha4.PlanHashForDDL(migration.Spec.GeneratedDDL)
+		migration.Status.PlanHash = planHash
+	}
+
+	text := fmt.Sprintf("SchemaHero migration approval required for %s/%s", migration.Namespace, migration.Name)
+	blocks := []map[string]interface{}{
+		{
+			"type": "section",
+			"text": map[string]interface{}{
+				"type": "mrkdwn",
+				"text": fmt.Sprintf("*SchemaHero migration approval required*\nMigration: `%s/%s`\nPlan hash: `%s`\nReact with :white_check_mark: to approve or :x: to deny.", migration.Namespace, migration.Name, planHash),
+			},
+		},
+		{
+			"type": "section",
+			"text": map[string]interface{}{
+				"type": "mrkdwn",
+				"text": "```" + migration.Spec.GeneratedDDL + "```",
+			},
+		},
+	}
+	ts, err := p.slackClient.PostMessage(ctx, p.channel, blocks, text, "")
+	if err != nil {
+		return err
+	}
+
+	updated := migration.DeepCopy()
+	annotations = updated.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[SlackChannelAnnotation] = p.channel
+	annotations[SlackMessageTSAnnotation] = ts
+	updated.SetAnnotations(annotations)
+	if updated.Status.PlanHash == "" {
+		updated.Status.PlanHash = planHash
+	}
+	_, err = p.schemasClient.Migrations(updated.Namespace).Update(ctx, updated, metav1.UpdateOptions{})
+	return err
+}
+
+func (p *Poller) handleReactions(ctx context.Context, migration *schemasv1alpha4.Migration) error {
+	annotations := migration.GetAnnotations()
+	channel := annotations[SlackChannelAnnotation]
+	ts := annotations[SlackMessageTSAnnotation]
+	if channel == "" || ts == "" {
+		return nil
+	}
+
+	reactions, err := p.slackClient.Reactions(ctx, channel, ts)
+	if err != nil {
+		return err
+	}
+
+	for _, reaction := range reactions {
+		switch reaction.Name {
+		case ApproveReaction:
+			if len(reaction.Users) == 0 {
+				continue
+			}
+			return p.approve(ctx, migration, reaction.Users[0])
+		case DenyReaction:
+			if len(reaction.Users) == 0 {
+				continue
+			}
+			return p.reject(ctx, migration, reaction.Users[0])
+		default:
+			if err := p.warnInvalidReaction(ctx, migration, reaction.Name, reaction.Users); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (p *Poller) approve(ctx context.Context, migration *schemasv1alpha4.Migration, userID string) error {
+	actor, err := p.slackClient.UserName(ctx, userID)
+	if err != nil {
+		actor = userID
+	}
+	planHash := migration.Status.PlanHash
+	if planHash == "" {
+		planHash = schemasv1alpha4.PlanHashForDDL(migration.Spec.GeneratedDDL)
+	}
+
+	updated := migration.DeepCopy()
+	updated.Status.ApprovedAt = p.now().Unix()
+	updated.Status.ApprovedBy = actor
+	updated.Status.ApprovedPlanHash = planHash
+	updated.Status.PlanHash = planHash
+	updated.Status.Phase = schemasv1alpha4.Approved
+	p.setAuditReplyAnnotation(updated, SlackApprovalReplyUser, userID)
+	updatedMigration, err := p.schemasClient.Migrations(updated.Namespace).Update(ctx, updated, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+	if err := p.postAuditReply(ctx, migration, SlackApprovalReplyUser, userID, fmt.Sprintf("<@%s> approved this migration at %s.", userID, p.now().UTC().Format(time.RFC3339))); err != nil {
+		return err
+	}
+
+	if release, ok := releaseFromMigration(updatedMigration); ok && p.dispatcher != nil {
+		go p.dispatchWhenReleaseExecuted(context.Background(), release, updatedMigration.Namespace)
+	}
+	return nil
+}
+
+func (p *Poller) reject(ctx context.Context, migration *schemasv1alpha4.Migration, userID string) error {
+	actor, err := p.slackClient.UserName(ctx, userID)
+	if err != nil {
+		actor = userID
+	}
+
+	updated := migration.DeepCopy()
+	updated.Status.RejectedAt = p.now().Unix()
+	updated.Status.RejectedBy = actor
+	updated.Status.Phase = schemasv1alpha4.Rejected
+	p.setAuditReplyAnnotation(updated, SlackRejectionReplyUser, userID)
+	_, err = p.schemasClient.Migrations(updated.Namespace).Update(ctx, updated, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+	return p.postAuditReply(ctx, migration, SlackRejectionReplyUser, userID, fmt.Sprintf("<@%s> denied this migration at %s.", userID, p.now().UTC().Format(time.RFC3339)))
+}
+
+func (p *Poller) setAuditReplyAnnotation(migration *schemasv1alpha4.Migration, annotation string, userID string) {
+	annotations := migration.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[annotation] = userID
+	migration.SetAnnotations(annotations)
+}
+
+func (p *Poller) postAuditReply(ctx context.Context, migration *schemasv1alpha4.Migration, annotation string, userID string, text string) error {
+	annotations := migration.GetAnnotations()
+	if annotations[annotation] == userID {
+		return nil
+	}
+	channel := annotations[SlackChannelAnnotation]
+	ts := annotations[SlackMessageTSAnnotation]
+	if channel == "" || ts == "" {
+		return nil
+	}
+	_, err := p.slackClient.PostMessage(ctx, channel, nil, text, ts)
+	return err
+}
+
+func (p *Poller) warnInvalidReaction(ctx context.Context, migration *schemasv1alpha4.Migration, reaction string, users []string) error {
+	if len(users) == 0 {
+		return nil
+	}
+
+	annotations := migration.GetAnnotations()
+	alreadyWarned := strings.Split(annotations[SlackInvalidReactionUsers], ",")
+	warned := map[string]bool{}
+	for _, user := range alreadyWarned {
+		if user != "" {
+			warned[user] = true
+		}
+	}
+
+	newWarnings := []string{}
+	for _, user := range users {
+		key := reaction + ":" + user
+		if warned[key] {
+			continue
+		}
+		newWarnings = append(newWarnings, key)
+		_, err := p.slackClient.PostMessage(
+			ctx,
+			annotations[SlackChannelAnnotation],
+			nil,
+			fmt.Sprintf("<@%s> `%s` is not a valid approval reaction. Use :white_check_mark: to approve or :x: to deny.", user, reaction),
+			annotations[SlackMessageTSAnnotation],
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(newWarnings) == 0 {
+		return nil
+	}
+
+	updated := migration.DeepCopy()
+	annotations = updated.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	if annotations[SlackInvalidReactionUsers] != "" {
+		annotations[SlackInvalidReactionUsers] += ","
+	}
+	annotations[SlackInvalidReactionUsers] += strings.Join(newWarnings, ",")
+	updated.SetAnnotations(annotations)
+	_, err := p.schemasClient.Migrations(updated.Namespace).Update(ctx, updated, metav1.UpdateOptions{})
+	return err
+}
+
+func (p *Poller) dispatchWhenReleaseExecuted(ctx context.Context, release Release, namespace string) {
+	timeout := p.dispatchTimeout
+	if timeout == 0 {
+		timeout = DefaultDispatchTimeout
+	}
+	pollInterval := p.pollInterval
+	if pollInterval == 0 {
+		pollInterval = DefaultPollInterval
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+	for {
+		ready, err := releaseMigrationsExecuted(ctx, p.schemasClient, release, namespace)
+		if err == nil && ready {
+			if p.dispatched[release.DispatchKey()] {
+				return
+			}
+			p.dispatched[release.DispatchKey()] = true
+			_ = p.dispatcher.Dispatch(ctx, release)
+			return
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}

--- a/pkg/slackapp/poller.go
+++ b/pkg/slackapp/poller.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -36,6 +37,7 @@ type Poller struct {
 	pendingInterval time.Duration
 	dispatchTimeout time.Duration
 	dispatched      map[string]bool
+	dispatchedMu    sync.Mutex
 	now             func() time.Time
 }
 
@@ -109,9 +111,10 @@ func (p *Poller) sync(ctx context.Context) (syncResult, error) {
 	result := syncResult{}
 	migrations, err := p.schemasClient.Migrations(p.namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return result, err
+		return result, errors.Wrap(err, "failed to list migrations")
 	}
 
+	var syncErr error
 	for i := range migrations.Items {
 		migration := &migrations.Items[i]
 		if migration.Status.Phase != schemasv1alpha4.Planned {
@@ -119,17 +122,27 @@ func (p *Poller) sync(ctx context.Context) (syncResult, error) {
 		}
 		result.pending = true
 
-		if err := p.ensureApprovalMessage(ctx, migration); err != nil {
-			result.retryAfter = retryAfter(err)
-			return result, err
+		updatedMessage, err := p.ensureApprovalMessage(ctx, migration)
+		if err != nil {
+			if result.retryAfter == 0 {
+				result.retryAfter = retryAfter(err)
+			}
+			syncErr = stderrors.Join(syncErr, errors.Wrapf(err, "failed to ensure approval message for migration %s/%s", migration.Namespace, migration.Name))
+			continue
+		}
+		if updatedMessage {
+			continue
 		}
 		if err := p.handleReactions(ctx, migration); err != nil {
-			result.retryAfter = retryAfter(err)
-			return result, err
+			if result.retryAfter == 0 {
+				result.retryAfter = retryAfter(err)
+			}
+			syncErr = stderrors.Join(syncErr, errors.Wrapf(err, "failed to handle reactions for migration %s/%s", migration.Namespace, migration.Name))
+			continue
 		}
 	}
 
-	return result, nil
+	return result, syncErr
 }
 
 func retryAfter(err error) time.Duration {
@@ -140,16 +153,11 @@ func retryAfter(err error) time.Duration {
 	return 0
 }
 
-func (p *Poller) ensureApprovalMessage(ctx context.Context, migration *schemasv1alpha4.Migration) error {
+func (p *Poller) ensureApprovalMessage(ctx context.Context, migration *schemasv1alpha4.Migration) (bool, error) {
 	annotations := migration.GetAnnotations()
-	if annotations[SlackMessageTSAnnotation] != "" {
-		return nil
-	}
-
-	planHash := migration.Status.PlanHash
-	if planHash == "" {
-		planHash = schemasv1alpha4.PlanHashForDDL(migration.Spec.GeneratedDDL)
-		migration.Status.PlanHash = planHash
+	planHash := schemasv1alpha4.PlanHashForDDL(migration.Spec.GeneratedDDL)
+	if annotations[SlackMessageTSAnnotation] != "" && migration.Status.PlanHash == planHash {
+		return false, nil
 	}
 
 	text := fmt.Sprintf("SchemaHero migration approval required for %s/%s", migration.Namespace, migration.Name)
@@ -171,7 +179,7 @@ func (p *Poller) ensureApprovalMessage(ctx context.Context, migration *schemasv1
 	}
 	ts, err := p.slackClient.PostMessage(ctx, p.channel, blocks, text, "")
 	if err != nil {
-		return err
+		return false, errors.Wrap(err, "failed to post slack approval message")
 	}
 
 	updated := migration.DeepCopy()
@@ -181,12 +189,13 @@ func (p *Poller) ensureApprovalMessage(ctx context.Context, migration *schemasv1
 	}
 	annotations[SlackChannelAnnotation] = p.channel
 	annotations[SlackMessageTSAnnotation] = ts
+	delete(annotations, SlackInvalidReactionUsers)
+	delete(annotations, SlackApprovalReplyUser)
+	delete(annotations, SlackRejectionReplyUser)
 	updated.SetAnnotations(annotations)
-	if updated.Status.PlanHash == "" {
-		updated.Status.PlanHash = planHash
-	}
+	updated.Status.PlanHash = planHash
 	_, err = p.schemasClient.Migrations(updated.Namespace).Update(ctx, updated, metav1.UpdateOptions{})
-	return err
+	return true, errors.Wrap(err, "failed to update migration slack approval annotations")
 }
 
 func (p *Poller) handleReactions(ctx context.Context, migration *schemasv1alpha4.Migration) error {
@@ -199,7 +208,7 @@ func (p *Poller) handleReactions(ctx context.Context, migration *schemasv1alpha4
 
 	reactions, err := p.slackClient.Reactions(ctx, channel, ts)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to fetch slack reactions")
 	}
 
 	for _, reaction := range reactions {
@@ -216,7 +225,7 @@ func (p *Poller) handleReactions(ctx context.Context, migration *schemasv1alpha4
 			return p.reject(ctx, migration, reaction.Users[0])
 		default:
 			if err := p.warnInvalidReaction(ctx, migration, reaction.Name, reaction.Users); err != nil {
-				return err
+				return errors.Wrapf(err, "failed to warn users for invalid slack reaction %q", reaction.Name)
 			}
 		}
 	}
@@ -243,14 +252,14 @@ func (p *Poller) approve(ctx context.Context, migration *schemasv1alpha4.Migrati
 	p.setAuditReplyAnnotation(updated, SlackApprovalReplyUser, userID)
 	updatedMigration, err := p.schemasClient.Migrations(updated.Namespace).Update(ctx, updated, metav1.UpdateOptions{})
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to update approved migration")
 	}
 	if err := p.postAuditReply(ctx, migration, SlackApprovalReplyUser, userID, fmt.Sprintf("<@%s> approved this migration at %s.", userID, p.now().UTC().Format(time.RFC3339))); err != nil {
-		return err
+		return errors.Wrap(err, "failed to post slack approval audit reply")
 	}
 
 	if release, ok := releaseFromMigration(updatedMigration); ok && p.dispatcher != nil {
-		go p.dispatchWhenReleaseExecuted(context.Background(), release, updatedMigration.Namespace)
+		go p.dispatchWhenReleaseExecuted(ctx, release, updatedMigration.Namespace)
 	}
 	return nil
 }
@@ -268,9 +277,9 @@ func (p *Poller) reject(ctx context.Context, migration *schemasv1alpha4.Migratio
 	p.setAuditReplyAnnotation(updated, SlackRejectionReplyUser, userID)
 	_, err = p.schemasClient.Migrations(updated.Namespace).Update(ctx, updated, metav1.UpdateOptions{})
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to update rejected migration")
 	}
-	return p.postAuditReply(ctx, migration, SlackRejectionReplyUser, userID, fmt.Sprintf("<@%s> denied this migration at %s.", userID, p.now().UTC().Format(time.RFC3339)))
+	return errors.Wrap(p.postAuditReply(ctx, migration, SlackRejectionReplyUser, userID, fmt.Sprintf("<@%s> denied this migration at %s.", userID, p.now().UTC().Format(time.RFC3339))), "failed to post slack rejection audit reply")
 }
 
 func (p *Poller) setAuditReplyAnnotation(migration *schemasv1alpha4.Migration, annotation string, userID string) {
@@ -293,7 +302,7 @@ func (p *Poller) postAuditReply(ctx context.Context, migration *schemasv1alpha4.
 		return nil
 	}
 	_, err := p.slackClient.PostMessage(ctx, channel, nil, text, ts)
-	return err
+	return errors.Wrap(err, "failed to post slack thread reply")
 }
 
 func (p *Poller) warnInvalidReaction(ctx context.Context, migration *schemasv1alpha4.Migration, reaction string, users []string) error {
@@ -325,7 +334,7 @@ func (p *Poller) warnInvalidReaction(ctx context.Context, migration *schemasv1al
 			annotations[SlackMessageTSAnnotation],
 		)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "failed to post invalid reaction warning")
 		}
 	}
 
@@ -344,7 +353,7 @@ func (p *Poller) warnInvalidReaction(ctx context.Context, migration *schemasv1al
 	annotations[SlackInvalidReactionUsers] += strings.Join(newWarnings, ",")
 	updated.SetAnnotations(annotations)
 	_, err := p.schemasClient.Migrations(updated.Namespace).Update(ctx, updated, metav1.UpdateOptions{})
-	return err
+	return errors.Wrap(err, "failed to update invalid reaction warning annotations")
 }
 
 func (p *Poller) dispatchWhenReleaseExecuted(ctx context.Context, release Release, namespace string) {
@@ -364,12 +373,15 @@ func (p *Poller) dispatchWhenReleaseExecuted(ctx context.Context, release Releas
 	defer ticker.Stop()
 	for {
 		ready, err := releaseMigrationsExecuted(ctx, p.schemasClient, release, namespace)
-		if err == nil && ready {
-			if p.dispatched[release.DispatchKey()] {
+		if err != nil {
+			log.Printf("schemahero slack app release dispatch readiness failed: %v", err)
+			if releaseReadinessErrorIsTerminal(err) {
 				return
 			}
-			p.dispatched[release.DispatchKey()] = true
-			_ = p.dispatcher.Dispatch(ctx, release)
+		} else if ready {
+			if p.markDispatched(release.DispatchKey()) {
+				_ = p.dispatcher.Dispatch(ctx, release)
+			}
 			return
 		}
 
@@ -379,4 +391,14 @@ func (p *Poller) dispatchWhenReleaseExecuted(ctx context.Context, release Releas
 		case <-ticker.C:
 		}
 	}
+}
+
+func (p *Poller) markDispatched(key string) bool {
+	p.dispatchedMu.Lock()
+	defer p.dispatchedMu.Unlock()
+	if p.dispatched[key] {
+		return false
+	}
+	p.dispatched[key] = true
+	return true
 }

--- a/pkg/slackapp/poller_test.go
+++ b/pkg/slackapp/poller_test.go
@@ -2,6 +2,8 @@ package slackapp
 
 import (
 	"context"
+	stderrors "errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -16,6 +18,7 @@ type fakeSlackClient struct {
 	reactions    []Reaction
 	reactionsErr error
 	users        map[string]string
+	failPostText string
 }
 
 type fakeSlackMessage struct {
@@ -25,6 +28,9 @@ type fakeSlackMessage struct {
 }
 
 func (c *fakeSlackClient) PostMessage(_ context.Context, channel string, _ []map[string]interface{}, text string, threadTS string) (string, error) {
+	if c.failPostText != "" && strings.Contains(text, c.failPostText) {
+		return "", stderrors.New("post failed")
+	}
 	c.messages = append(c.messages, fakeSlackMessage{
 		channel:  channel,
 		text:     text,
@@ -60,6 +66,47 @@ func TestPollerPostsApprovalMessage(t *testing.T) {
 	updated, err := client.Migrations("default").Get(context.Background(), "approval-rehearsal", metav1.GetOptions{})
 	require.NoError(t, err)
 	require.Equal(t, "C123", updated.Annotations[SlackChannelAnnotation])
+	require.Equal(t, "123.456", updated.Annotations[SlackMessageTSAnnotation])
+}
+
+func TestPollerRepostsApprovalMessageWhenPlanHashChanges(t *testing.T) {
+	migration := plannedMigration("approval-rehearsal")
+	migration.Spec.GeneratedDDL = "select 2"
+	migration.Status.PlanHash = "old-plan"
+	migration.Annotations[SlackChannelAnnotation] = "C123"
+	migration.Annotations[SlackMessageTSAnnotation] = "old-ts"
+	migration.Annotations[SlackInvalidReactionUsers] = "eyes:U123"
+	client := testclient.NewSimpleClientset(migration).SchemasV1alpha4()
+	slack := &fakeSlackClient{
+		reactions: []Reaction{{Name: ApproveReaction, Users: []string{"U123"}}},
+	}
+	poller := NewPoller(client, slack, "C123", "default")
+
+	require.NoError(t, poller.Sync(context.Background()))
+
+	require.Len(t, slack.messages, 1)
+	updated, err := client.Migrations("default").Get(context.Background(), "approval-rehearsal", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, schemasv1alpha4.Planned, updated.Status.Phase)
+	require.Equal(t, schemasv1alpha4.PlanHashForDDL("select 2"), updated.Status.PlanHash)
+	require.Equal(t, "123.456", updated.Annotations[SlackMessageTSAnnotation])
+	require.NotContains(t, updated.Annotations, SlackInvalidReactionUsers)
+}
+
+func TestPollerContinuesAfterMigrationError(t *testing.T) {
+	broken := plannedMigration("broken")
+	ok := plannedMigration("ok")
+	client := testclient.NewSimpleClientset(broken, ok).SchemasV1alpha4()
+	slack := &fakeSlackClient{failPostText: "broken"}
+	poller := NewPoller(client, slack, "C123", "default")
+
+	err := poller.Sync(context.Background())
+
+	require.Error(t, err)
+	require.Len(t, slack.messages, 1)
+	require.Contains(t, slack.messages[0].text, "ok")
+	updated, getErr := client.Migrations("default").Get(context.Background(), "ok", metav1.GetOptions{})
+	require.NoError(t, getErr)
 	require.Equal(t, "123.456", updated.Annotations[SlackMessageTSAnnotation])
 }
 

--- a/pkg/slackapp/poller_test.go
+++ b/pkg/slackapp/poller_test.go
@@ -1,0 +1,180 @@
+package slackapp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	schemasv1alpha4 "github.com/schemahero/schemahero/pkg/apis/schemas/v1alpha4"
+	testclient "github.com/schemahero/schemahero/pkg/client/schemaheroclientset/fake"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type fakeSlackClient struct {
+	messages     []fakeSlackMessage
+	reactions    []Reaction
+	reactionsErr error
+	users        map[string]string
+}
+
+type fakeSlackMessage struct {
+	channel  string
+	text     string
+	threadTS string
+}
+
+func (c *fakeSlackClient) PostMessage(_ context.Context, channel string, _ []map[string]interface{}, text string, threadTS string) (string, error) {
+	c.messages = append(c.messages, fakeSlackMessage{
+		channel:  channel,
+		text:     text,
+		threadTS: threadTS,
+	})
+	return "123.456", nil
+}
+
+func (c *fakeSlackClient) Reactions(_ context.Context, _ string, _ string) ([]Reaction, error) {
+	if c.reactionsErr != nil {
+		return nil, c.reactionsErr
+	}
+	return c.reactions, nil
+}
+
+func (c *fakeSlackClient) UserName(_ context.Context, userID string) (string, error) {
+	if c.users != nil && c.users[userID] != "" {
+		return c.users[userID], nil
+	}
+	return userID, nil
+}
+
+func TestPollerPostsApprovalMessage(t *testing.T) {
+	migration := plannedMigration("approval-rehearsal")
+	client := testclient.NewSimpleClientset(migration).SchemasV1alpha4()
+	slack := &fakeSlackClient{}
+	poller := NewPoller(client, slack, "C123", "default")
+
+	require.NoError(t, poller.Sync(context.Background()))
+
+	require.Len(t, slack.messages, 1)
+	require.Contains(t, slack.messages[0].text, "approval-rehearsal")
+	updated, err := client.Migrations("default").Get(context.Background(), "approval-rehearsal", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, "C123", updated.Annotations[SlackChannelAnnotation])
+	require.Equal(t, "123.456", updated.Annotations[SlackMessageTSAnnotation])
+}
+
+func TestPollerUsesPendingIntervalWhenMigrationNeedsApproval(t *testing.T) {
+	migration := plannedMigration("approval-rehearsal")
+	client := testclient.NewSimpleClientset(migration).SchemasV1alpha4()
+	slack := &fakeSlackClient{}
+	poller := NewPoller(client, slack, "C123", "default")
+	poller.pollInterval = 15 * time.Second
+	poller.pendingInterval = 5 * time.Second
+
+	require.Equal(t, 5*time.Second, poller.syncAndLog(context.Background()))
+}
+
+func TestPollerUsesRetryAfterWhenSlackRateLimited(t *testing.T) {
+	migration := plannedMigration("approval-rehearsal")
+	migration.Annotations[SlackChannelAnnotation] = "C123"
+	migration.Annotations[SlackMessageTSAnnotation] = "123.456"
+	client := testclient.NewSimpleClientset(migration).SchemasV1alpha4()
+	slack := &fakeSlackClient{
+		reactionsErr: &RateLimitError{RetryAfter: 30 * time.Second},
+	}
+	poller := NewPoller(client, slack, "C123", "default")
+	poller.pollInterval = 15 * time.Second
+	poller.pendingInterval = 5 * time.Second
+
+	require.Equal(t, 30*time.Second, poller.syncAndLog(context.Background()))
+}
+
+func TestPollerApprovesOnWhiteCheckReaction(t *testing.T) {
+	migration := plannedMigration("approval-rehearsal")
+	migration.Annotations[SlackChannelAnnotation] = "C123"
+	migration.Annotations[SlackMessageTSAnnotation] = "123.456"
+	client := testclient.NewSimpleClientset(migration).SchemasV1alpha4()
+	slack := &fakeSlackClient{
+		reactions: []Reaction{{Name: ApproveReaction, Users: []string{"U123"}}},
+		users:     map[string]string{"U123": "Marc"},
+	}
+	poller := NewPoller(client, slack, "C123", "default")
+	poller.now = func() time.Time { return time.Unix(100, 0) }
+
+	require.NoError(t, poller.Sync(context.Background()))
+
+	updated, err := client.Migrations("default").Get(context.Background(), "approval-rehearsal", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, schemasv1alpha4.Approved, updated.Status.Phase)
+	require.Equal(t, "Marc", updated.Status.ApprovedBy)
+	require.Equal(t, updated.Status.PlanHash, updated.Status.ApprovedPlanHash)
+	require.Len(t, slack.messages, 1)
+	require.Equal(t, "123.456", slack.messages[0].threadTS)
+	require.Contains(t, slack.messages[0].text, "<@U123> approved this migration at 1970-01-01T00:01:40Z.")
+}
+
+func TestPollerRejectsOnXReaction(t *testing.T) {
+	migration := plannedMigration("approval-rehearsal")
+	migration.Annotations[SlackChannelAnnotation] = "C123"
+	migration.Annotations[SlackMessageTSAnnotation] = "123.456"
+	client := testclient.NewSimpleClientset(migration).SchemasV1alpha4()
+	slack := &fakeSlackClient{
+		reactions: []Reaction{{Name: DenyReaction, Users: []string{"U123"}}},
+		users:     map[string]string{"U123": "Marc"},
+	}
+	poller := NewPoller(client, slack, "C123", "default")
+	poller.now = func() time.Time { return time.Unix(100, 0) }
+
+	require.NoError(t, poller.Sync(context.Background()))
+
+	updated, err := client.Migrations("default").Get(context.Background(), "approval-rehearsal", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, schemasv1alpha4.Rejected, updated.Status.Phase)
+	require.Equal(t, "Marc", updated.Status.RejectedBy)
+	require.Len(t, slack.messages, 1)
+	require.Equal(t, "123.456", slack.messages[0].threadTS)
+	require.Contains(t, slack.messages[0].text, "<@U123> denied this migration at 1970-01-01T00:01:40Z.")
+}
+
+func TestPollerWarnsOnInvalidReaction(t *testing.T) {
+	migration := plannedMigration("approval-rehearsal")
+	migration.Annotations[SlackChannelAnnotation] = "C123"
+	migration.Annotations[SlackMessageTSAnnotation] = "123.456"
+	client := testclient.NewSimpleClientset(migration).SchemasV1alpha4()
+	slack := &fakeSlackClient{
+		reactions: []Reaction{{Name: "eyes", Users: []string{"U123"}}},
+	}
+	poller := NewPoller(client, slack, "C123", "default")
+
+	require.NoError(t, poller.Sync(context.Background()))
+
+	require.Len(t, slack.messages, 1)
+	require.Equal(t, "123.456", slack.messages[0].threadTS)
+	require.Contains(t, slack.messages[0].text, "Use :white_check_mark: to approve or :x: to deny")
+	updated, err := client.Migrations("default").Get(context.Background(), "approval-rehearsal", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Contains(t, updated.Annotations[SlackInvalidReactionUsers], "eyes:U123")
+}
+
+func plannedMigration(name string) *schemasv1alpha4.Migration {
+	ddl := "select 1"
+	return &schemasv1alpha4.Migration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Annotations: map[string]string{
+				ReleaseTagAnnotation:      "v2099.01.01-0",
+				ReleaseSHAAnnotation:      "1111111111111111111111111111111111111111",
+				PreviousSHAAnnotation:     "0000000000000000000000000000000000000000",
+				PreviousTagNameAnnotation: "v2098.12.31-0",
+			},
+		},
+		Spec: schemasv1alpha4.MigrationSpec{
+			GeneratedDDL: ddl,
+		},
+		Status: schemasv1alpha4.MigrationStatus{
+			Phase:    schemasv1alpha4.Planned,
+			PlanHash: schemasv1alpha4.PlanHashForDDL(ddl),
+		},
+	}
+}

--- a/pkg/slackapp/release.go
+++ b/pkg/slackapp/release.go
@@ -1,0 +1,53 @@
+package slackapp
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	schemasv1alpha4 "github.com/schemahero/schemahero/pkg/apis/schemas/v1alpha4"
+	schemasclientv1alpha4 "github.com/schemahero/schemahero/pkg/client/schemaheroclientset/typed/schemas/v1alpha4"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+func releaseFromMigration(migration *schemasv1alpha4.Migration) (Release, bool) {
+	annotations := migration.GetAnnotations()
+	release := Release{
+		Tag:             annotations[ReleaseTagAnnotation],
+		SHA:             annotations[ReleaseSHAAnnotation],
+		PreviousSHA:     annotations[PreviousSHAAnnotation],
+		PreviousTagName: annotations[PreviousTagNameAnnotation],
+	}
+	if release.Tag == "" || release.SHA == "" || release.PreviousSHA == "" || release.PreviousTagName == "" {
+		return Release{}, false
+	}
+	return release, true
+}
+
+func releaseMigrationsExecuted(ctx context.Context, schemasClient schemasclientv1alpha4.SchemasV1alpha4Interface, release Release, namespace string) (bool, error) {
+	migrations, err := schemasClient.Migrations(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labels.Everything().String(),
+	})
+	if err != nil {
+		return false, err
+	}
+
+	matched := 0
+	for _, migration := range migrations.Items {
+		annotations := migration.GetAnnotations()
+		if annotations[ReleaseTagAnnotation] != release.Tag || annotations[ReleaseSHAAnnotation] != release.SHA {
+			continue
+		}
+		matched++
+		switch migration.Status.Phase {
+		case schemasv1alpha4.Executed:
+			continue
+		case schemasv1alpha4.Rejected, schemasv1alpha4.Invalid:
+			return false, errors.Errorf("migration %s/%s is %s", migration.Namespace, migration.Name, migration.Status.Phase)
+		default:
+			return false, nil
+		}
+	}
+
+	return matched > 0, nil
+}

--- a/pkg/slackapp/release.go
+++ b/pkg/slackapp/release.go
@@ -2,12 +2,18 @@ package slackapp
 
 import (
 	"context"
+	stderrors "errors"
 
 	"github.com/pkg/errors"
 	schemasv1alpha4 "github.com/schemahero/schemahero/pkg/apis/schemas/v1alpha4"
 	schemasclientv1alpha4 "github.com/schemahero/schemahero/pkg/client/schemaheroclientset/typed/schemas/v1alpha4"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+)
+
+var (
+	errNoReleaseMigrations = stderrors.New("no matching release migrations")
+	errReleaseMigrationEnd = stderrors.New("release migration reached terminal phase")
 )
 
 func releaseFromMigration(migration *schemasv1alpha4.Migration) (Release, bool) {
@@ -29,7 +35,7 @@ func releaseMigrationsExecuted(ctx context.Context, schemasClient schemasclientv
 		LabelSelector: labels.Everything().String(),
 	})
 	if err != nil {
-		return false, err
+		return false, errors.Wrap(err, "failed to list release migrations")
 	}
 
 	matched := 0
@@ -43,11 +49,18 @@ func releaseMigrationsExecuted(ctx context.Context, schemasClient schemasclientv
 		case schemasv1alpha4.Executed:
 			continue
 		case schemasv1alpha4.Rejected, schemasv1alpha4.Invalid:
-			return false, errors.Errorf("migration %s/%s is %s", migration.Namespace, migration.Name, migration.Status.Phase)
+			return false, errors.Wrapf(errReleaseMigrationEnd, "migration %s/%s is %s", migration.Namespace, migration.Name, migration.Status.Phase)
 		default:
 			return false, nil
 		}
 	}
 
-	return matched > 0, nil
+	if matched == 0 {
+		return false, errors.Wrapf(errNoReleaseMigrations, "release %s at %s", release.Tag, release.SHA)
+	}
+	return true, nil
+}
+
+func releaseReadinessErrorIsTerminal(err error) bool {
+	return stderrors.Is(err, errNoReleaseMigrations) || stderrors.Is(err, errReleaseMigrationEnd)
 }

--- a/pkg/slackapp/release_test.go
+++ b/pkg/slackapp/release_test.go
@@ -1,0 +1,53 @@
+package slackapp
+
+import (
+	"context"
+	"testing"
+
+	schemasv1alpha4 "github.com/schemahero/schemahero/pkg/apis/schemas/v1alpha4"
+	testclient "github.com/schemahero/schemahero/pkg/client/schemaheroclientset/fake"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestReleaseMigrationsExecutedRequiresMatchingMigrations(t *testing.T) {
+	client := testclient.NewSimpleClientset(plannedMigration("other-release")).SchemasV1alpha4()
+
+	ready, err := releaseMigrationsExecuted(context.Background(), client, Release{
+		Tag: "v2099.01.01-1",
+		SHA: "2222222222222222222222222222222222222222",
+	}, "default")
+
+	require.False(t, ready)
+	require.Error(t, err)
+	require.True(t, releaseReadinessErrorIsTerminal(err))
+}
+
+func TestReleaseMigrationsExecutedReturnsReadyWhenMatchesAreExecuted(t *testing.T) {
+	migration := plannedMigration("executed")
+	migration.Status.Phase = schemasv1alpha4.Executed
+	client := testclient.NewSimpleClientset(migration).SchemasV1alpha4()
+
+	ready, err := releaseMigrationsExecuted(context.Background(), client, Release{
+		Tag: migration.Annotations[ReleaseTagAnnotation],
+		SHA: migration.Annotations[ReleaseSHAAnnotation],
+	}, "default")
+
+	require.NoError(t, err)
+	require.True(t, ready)
+}
+
+func TestReleaseMigrationsExecutedReturnsTerminalErrorForRejectedMigration(t *testing.T) {
+	migration := plannedMigration("rejected")
+	migration.Status.Phase = schemasv1alpha4.Rejected
+	client := testclient.NewSimpleClientset(migration).SchemasV1alpha4()
+
+	ready, err := releaseMigrationsExecuted(context.Background(), client, Release{
+		Tag: migration.Annotations[ReleaseTagAnnotation],
+		SHA: migration.Annotations[ReleaseSHAAnnotation],
+	}, metav1.NamespaceDefault)
+
+	require.False(t, ready)
+	require.Error(t, err)
+	require.True(t, releaseReadinessErrorIsTerminal(err))
+}

--- a/pkg/slackapp/slack_client.go
+++ b/pkg/slackapp/slack_client.go
@@ -1,0 +1,200 @@
+package slackapp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+type SlackClient interface {
+	PostMessage(ctx context.Context, channel string, blocks []map[string]interface{}, text string, threadTS string) (string, error)
+	Reactions(ctx context.Context, channel string, timestamp string) ([]Reaction, error)
+	UserName(ctx context.Context, userID string) (string, error)
+}
+
+type Reaction struct {
+	Name  string
+	Users []string
+}
+
+type RateLimitError struct {
+	RetryAfter time.Duration
+	Message    string
+}
+
+func (e *RateLimitError) Error() string {
+	if e.Message != "" {
+		return e.Message
+	}
+	return "slack api rate limited"
+}
+
+type WebAPIClient struct {
+	token      string
+	httpClient *http.Client
+}
+
+func NewWebAPIClient(token string) *WebAPIClient {
+	return &WebAPIClient{
+		token:      token,
+		httpClient: http.DefaultClient,
+	}
+}
+
+func (c *WebAPIClient) PostMessage(ctx context.Context, channel string, blocks []map[string]interface{}, text string, threadTS string) (string, error) {
+	payload := map[string]interface{}{
+		"channel": channel,
+		"text":    text,
+	}
+	if len(blocks) > 0 {
+		payload["blocks"] = blocks
+	}
+	if threadTS != "" {
+		payload["thread_ts"] = threadTS
+	}
+
+	var response struct {
+		OK    bool   `json:"ok"`
+		Error string `json:"error"`
+		TS    string `json:"ts"`
+	}
+	if err := c.post(ctx, "https://slack.com/api/chat.postMessage", payload, &response); err != nil {
+		return "", err
+	}
+	if !response.OK {
+		return "", errors.Errorf("slack chat.postMessage failed: %s", response.Error)
+	}
+	return response.TS, nil
+}
+
+func (c *WebAPIClient) Reactions(ctx context.Context, channel string, timestamp string) ([]Reaction, error) {
+	var response struct {
+		OK      bool   `json:"ok"`
+		Error   string `json:"error"`
+		Message struct {
+			Reactions []Reaction `json:"reactions"`
+		} `json:"message"`
+	}
+	query := url.Values{}
+	query.Set("channel", channel)
+	query.Set("timestamp", timestamp)
+	if err := c.get(ctx, "https://slack.com/api/reactions.get", query, &response); err != nil {
+		return nil, err
+	}
+	if !response.OK {
+		return nil, errors.Errorf("slack reactions.get failed: %s", response.Error)
+	}
+	return response.Message.Reactions, nil
+}
+
+func (c *WebAPIClient) UserName(ctx context.Context, userID string) (string, error) {
+	var response struct {
+		OK    bool   `json:"ok"`
+		Error string `json:"error"`
+		User  struct {
+			Name    string `json:"name"`
+			Profile struct {
+				RealName string `json:"real_name"`
+			} `json:"profile"`
+		} `json:"user"`
+	}
+	query := url.Values{}
+	query.Set("user", userID)
+	if err := c.get(ctx, "https://slack.com/api/users.info", query, &response); err != nil {
+		return "", err
+	}
+	if !response.OK {
+		return "", errors.Errorf("slack users.info failed: %s", response.Error)
+	}
+	if response.User.Profile.RealName != "" {
+		return response.User.Profile.RealName, nil
+	}
+	if response.User.Name != "" {
+		return response.User.Name, nil
+	}
+	return userID, nil
+}
+
+func (c *WebAPIClient) get(ctx context.Context, rawURL string, query url.Values, response interface{}) error {
+	reqURL, err := url.Parse(rawURL)
+	if err != nil {
+		return err
+	}
+	reqURL.RawQuery = query.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL.String(), nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		if resp.StatusCode == http.StatusTooManyRequests {
+			return rateLimitError(resp)
+		}
+		return errors.Errorf("slack api returned %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+	return json.Unmarshal(respBody, response)
+}
+
+func (c *WebAPIClient) post(ctx context.Context, url string, payload interface{}, response interface{}) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		if resp.StatusCode == http.StatusTooManyRequests {
+			return rateLimitError(resp)
+		}
+		return errors.Errorf("slack api returned %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+	return json.Unmarshal(respBody, response)
+}
+
+func rateLimitError(resp *http.Response) error {
+	retryAfter := time.Minute
+	if header := resp.Header.Get("Retry-After"); header != "" {
+		if seconds, err := strconv.Atoi(header); err == nil && seconds > 0 {
+			retryAfter = time.Duration(seconds) * time.Second
+		}
+	}
+	return &RateLimitError{
+		RetryAfter: retryAfter,
+		Message:    "slack api rate limited",
+	}
+}


### PR DESCRIPTION
## Summary
- add stable SchemaHero migration plan hashes for exact SQL approval
- record approved/rejected actors and approved plan hash in migration status
- reject stale approve/reject CLI actions when an expected plan hash no longer matches
- require approved plan hash to match the current plan before applying migrations

## Validation
- go test ./pkg/controller/migration
- go test ./pkg/cli/schemaherokubectlcli
- go test ./pkg/apis/schemas/v1alpha4
- git diff --check