### PR TITLE
postgres: wire USING clause for non-btree indexes

### DIFF
--- a/pkg/database/types/index.go
+++ b/pkg/database/types/index.go
@@ -11,6 +11,7 @@ type Index struct {
 	Columns  []string
 	Name     string
 	IsUnique bool
+	Method   string
 	With     map[string]string
 }
 
@@ -20,6 +21,10 @@ func (idx *Index) Equals(other *Index) bool {
 	}
 
 	if idx.IsUnique != other.IsUnique {
+		return false
+	}
+
+	if idx.Method != other.Method {
 		return false
 	}
 
@@ -57,6 +62,7 @@ func IndexToPostgresqlSchemaIndex(index *Index) *schemasv1alpha4.PostgresqlTable
 		Columns:  index.Columns,
 		Name:     index.Name,
 		IsUnique: index.IsUnique,
+		Type:     index.Method,
 	}
 
 	return &schemaIndex
@@ -97,6 +103,7 @@ func PostgresqlSchemaIndexToIndex(schemaIndex *schemasv1alpha4.PostgresqlTableIn
 		Columns:  schemaIndex.Columns,
 		Name:     schemaIndex.Name,
 		IsUnique: schemaIndex.IsUnique,
+		Method:   schemaIndex.Type,
 	}
 
 	return &index

--- a/plugins/postgres/lib/index.go
+++ b/plugins/postgres/lib/index.go
@@ -32,10 +32,16 @@ func AddIndexStatement(tableName string, schemaIndex *schemasv1alpha4.Postgresql
 		name = types.GeneratePostgresqlIndexName(tableName, schemaIndex)
 	}
 
-	statement := fmt.Sprintf("create %sindex %s on %s (%s)",
+	using := ""
+	if schemaIndex.Type != "" {
+		using = fmt.Sprintf(" using %s", schemaIndex.Type)
+	}
+
+	statement := fmt.Sprintf("create %sindex %s on %s%s (%s)",
 		unique,
 		name,
 		tableName,
+		using,
 		strings.Join(schemaIndex.Columns, ", "))
 
 	if schemaIndex.With != nil && len(schemaIndex.With) > 0 {


### PR DESCRIPTION
﻿Fixes #1351 — the PostgreSQL index `type` field (gin, brin, gist, etc.) was accepted by the CRD but silently ignored by the code generator.

## Root cause

`AddIndexStatement` in `plugins/postgres/lib/index.go` never read `schemaIndex.Type`, so every index was generated as a plain btree regardless of what the user specified. Additionally, the `types.Index` struct used for drift detection had no `Method` field, so a change in index method would never trigger a migration.

## Changes

**`plugins/postgres/lib/index.go`**
- Read `schemaIndex.Type` and append a `USING <type>` clause to the `CREATE INDEX` statement when it is non-empty (btree is the PostgreSQL default and needs no explicit clause).

**`pkg/database/types/index.go`**
- Add `Method string` to `Index` struct.
- Include `Method != other.Method` in `Equals()` so drift detection catches index method changes.
- Copy `Type` ↔ `Method` in `PostgresqlSchemaIndexToIndex` / `IndexToPostgresqlSchemaIndex`.

## Before / After

```sql
-- Before (type: gin ignored)
CREATE INDEX idx_test_reports_tests ON test_reports (tests)

-- After
CREATE INDEX idx_test_reports_tests ON test_reports USING gin (tests)
```
