### PR TITLE
Pin unpinned-action references across 6 workflows

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -19,8 +19,8 @@ jobs:
       rqlite: ${{ steps.filter.outputs.rqlite }}
       timescaledb: ${{ steps.filter.outputs.timescaledb }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         id: filter
         with:
           filters: |
@@ -58,24 +58,24 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: 'go.mod'
           cache: true
           cache-dependency-path: ./go.sum
 
       - run: make manifests bin/kubectl-schemahero manager bin/schemahero-slack-app
-      - uses: actions/upload-artifact@v7.0.1
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: kubectl-schemahero
           path: bin/kubectl-schemahero
-      - uses: actions/upload-artifact@v7.0.1
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: manager
           path: bin/manager
-      - uses: actions/upload-artifact@v7.0.1
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: schemahero-slack-app
           path: bin/schemahero-slack-app
@@ -83,9 +83,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: 'go.mod'
           cache: true
@@ -114,11 +114,11 @@ jobs:
       needs.changes.outputs.core == 'true'
       || github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
       - name: Build slack app image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
         with:
           context: .
           file: deploy/Dockerfile.multiarch
@@ -162,9 +162,9 @@ jobs:
             path: plugins/cassandra
             package: ./lib
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: '${{ matrix.plugin.path }}/go.mod'
           cache: true
@@ -187,14 +187,14 @@ jobs:
       matrix:
         postgres_version: ${{ github.ref == 'refs/heads/main' && fromJson('["14.20","15.15","16.11","17.7","18.1"]') || fromJson('["18.1"]') }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: 'go.mod'
           cache: true
           cache-dependency-path: ./go.sum
       - name: Download kubectl-schemahero binary
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: kubectl-schemahero
           path: bin/
@@ -220,14 +220,14 @@ jobs:
       matrix:
         mysql_version: ${{ github.ref == 'refs/heads/main' && fromJson('["8.0.45","8.4.8","9.5.2"]') || fromJson('["9.5.2"]') }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: 'go.mod'
           cache: true
           cache-dependency-path: ./go.sum
       - name: Download kubectl-schemahero binary
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: kubectl-schemahero
           path: bin/
@@ -253,14 +253,14 @@ jobs:
       matrix:
         cockroachdb_version: ${{ github.ref == 'refs/heads/main' && fromJson('["v24.3.25","v25.2.11","v25.4.3"]') || fromJson('["v25.4.3"]') }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: 'go.mod'
           cache: true
           cache-dependency-path: ./go.sum
       - name: Download kubectl-schemahero binary
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: kubectl-schemahero
           path: bin/
@@ -286,14 +286,14 @@ jobs:
       matrix:
         cassandra_version: ${{ github.ref == 'refs/heads/main' && fromJson('["4.0.19","4.1.10","5.0.6"]') || fromJson('["5.0.6"]') }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: 'go.mod'
           cache: true
           cache-dependency-path: ./go.sum
       - name: Download kubectl-schemahero binary
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: kubectl-schemahero
           path: bin/
@@ -319,14 +319,14 @@ jobs:
       matrix:
         sqlite_version: ["3.51.2"]
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: 'go.mod'
           cache: true
           cache-dependency-path: ./go.sum
       - name: Download kubectl-schemahero binary
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: kubectl-schemahero
           path: bin/
@@ -352,14 +352,14 @@ jobs:
       matrix:
         rqlite_version: ${{ github.ref == 'refs/heads/main' && fromJson('["8.36.8","9.3.18"]') || fromJson('["9.3.18"]') }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: 'go.mod'
           cache: true
           cache-dependency-path: ./go.sum
       - name: Download kubectl-schemahero binary
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: kubectl-schemahero
           path: bin/
@@ -385,14 +385,14 @@ jobs:
       matrix:
         timescaledb_version: ["2.25.0-pg17"]
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: 'go.mod'
           cache: true
           cache-dependency-path: ./go.sum
       - name: Download kubectl-schemahero binary
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: kubectl-schemahero
           path: bin/
@@ -410,9 +410,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       - name: Download kubectl-schemahero binary
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: kubectl-schemahero
           path: bin/

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,9 +35,9 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
-    - uses: actions/setup-go@v6
+    - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
       with:
         go-version-file: 'go.mod'
         cache: true
@@ -45,7 +45,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -56,7 +56,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v4
+      uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -70,4 +70,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e

--- a/.github/workflows/factory-publish.yaml
+++ b/.github/workflows/factory-publish.yaml
@@ -20,17 +20,17 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Publish factory (schemahero-issues)
-        uses: elasticclaw/actions/publish-factory@main
+        uses: elasticclaw/actions/publish-factory@cac6be311a97b343108a3a1e4325e8063891c030
         with:
           hub-endpoint: https://factory.repldev.com
           token: ${{ secrets.ELASTICCLAW_TOKEN }}
           path: .elasticclaw/factories/schemahero-issues
 
       - name: Publish template (schemahero-developer)
-        uses: elasticclaw/actions/publish-template@main
+        uses: elasticclaw/actions/publish-template@cac6be311a97b343108a3a1e4325e8063891c030
         with:
           hub-endpoint: https://factory.repldev.com
           token: ${{ secrets.ELASTICCLAW_TOKEN }}

--- a/.github/workflows/factory-validate.yaml
+++ b/.github/workflows/factory-validate.yaml
@@ -17,10 +17,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Validate factory (schemahero-issues)
-        uses: elasticclaw/actions/publish-factory@main
+        uses: elasticclaw/actions/publish-factory@cac6be311a97b343108a3a1e4325e8063891c030
         with:
           hub-endpoint: https://factory.repldev.com
           token: ${{ secrets.ELASTICCLAW_TOKEN }}
@@ -28,7 +28,7 @@ jobs:
           dry-run: true
 
       - name: Validate template (schemahero-developer)
-        uses: elasticclaw/actions/publish-template@main
+        uses: elasticclaw/actions/publish-template@cac6be311a97b343108a3a1e4325e8063891c030
         with:
           hub-endpoint: https://factory.repldev.com
           token: ${{ secrets.ELASTICCLAW_TOKEN }}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -20,10 +20,10 @@ jobs:
   nix-build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
     - name: Install Nix
-      uses: cachix/install-nix-action@v31
+      uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3
       with:
         nix_path: nixpkgs=channel:nixos-unstable
         extra_nix_config: |
@@ -46,10 +46,10 @@ jobs:
   nix-develop:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
     - name: Install Nix
-      uses: cachix/install-nix-action@v31
+      uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3
       with:
         nix_path: nixpkgs=channel:nixos-unstable
         extra_nix_config: |
@@ -69,12 +69,12 @@ jobs:
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Install Nix
-      uses: cachix/install-nix-action@v31
+      uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3
       with:
         nix_path: nixpkgs=channel:nixos-unstable
         extra_nix_config: |
@@ -99,7 +99,7 @@ jobs:
 
     - name: Create Pull Request
       if: github.event_name == 'release'
-      uses: peter-evans/create-pull-request@v8
+      uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         commit-message: "nix: update schemahero to ${{ github.ref_name }}"

--- a/.github/workflows/tagged-release.yaml
+++ b/.github/workflows/tagged-release.yaml
@@ -19,8 +19,8 @@ jobs:
       rqlite: ${{ steps.filter.outputs.rqlite }}
       cassandra: ${{ steps.filter.outputs.cassandra }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         id: filter
         with:
           filters: |
@@ -48,14 +48,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Get plugin version
         id: version
         run: echo "VERSION=$(cat plugins/postgres/VERSION)" >> $GITHUB_OUTPUT
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: 'go.mod'
           cache: true
@@ -78,14 +78,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Get plugin version
         id: version
         run: echo "VERSION=$(cat plugins/mysql/VERSION)" >> $GITHUB_OUTPUT
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: 'go.mod'
           cache: true
@@ -108,14 +108,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Get plugin version
         id: version
         run: echo "VERSION=$(cat plugins/timescaledb/VERSION)" >> $GITHUB_OUTPUT
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: 'go.mod'
           cache: true
@@ -138,14 +138,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Get plugin version
         id: version
         run: echo "VERSION=$(cat plugins/sqlite/VERSION)" >> $GITHUB_OUTPUT
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: 'go.mod'
           cache: true
@@ -168,14 +168,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Get plugin version
         id: version
         run: echo "VERSION=$(cat plugins/rqlite/VERSION)" >> $GITHUB_OUTPUT
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: 'go.mod'
           cache: true
@@ -198,14 +198,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Get plugin version
         id: version
         run: echo "VERSION=$(cat plugins/cassandra/VERSION)" >> $GITHUB_OUTPUT
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: 'go.mod'
           cache: true
@@ -227,9 +227,9 @@ jobs:
     needs: [build-postgres, build-mysql, build-timescaledb, build-sqlite, build-rqlite, build-cassandra]
     if: always() && !cancelled()
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: 'go.mod'
           cache: true
@@ -239,11 +239,11 @@ jobs:
       - run: go mod tidy
       - run: git diff
       - run: make vet manifests bin/kubectl-schemahero manager test
-      - uses: actions/upload-artifact@v7.0.1
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: manager
           path: bin/manager
-      - uses: actions/upload-artifact@v7.0.1
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: kubectl-schemahero
           path: bin/kubectl-schemahero
@@ -256,12 +256,12 @@ jobs:
       matrix:
         postgres_version: ["14.20", "15.15", "16.11", "17.7", "18.1"]
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: 'go.mod'
       - name: Download kubectl-schemahero binary
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: kubectl-schemahero
           path: bin/
@@ -282,12 +282,12 @@ jobs:
       matrix:
         mysql_version: ["8.0.45", "8.4.8", "9.5.2"]
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: 'go.mod'
       - name: Download kubectl-schemahero binary
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: kubectl-schemahero
           path: bin/
@@ -308,12 +308,12 @@ jobs:
       matrix:
         cockroachdb_version: ["v24.3.25", "v25.2.11", "v25.4.3"]
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: 'go.mod'
       - name: Download kubectl-schemahero binary
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: kubectl-schemahero
           path: bin/
@@ -334,12 +334,12 @@ jobs:
       matrix:
         cassandra_version: ["4.0.19", "4.1.10", "5.0.6"]
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: 'go.mod'
       - name: Download kubectl-schemahero binary
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: kubectl-schemahero
           path: bin/
@@ -360,12 +360,12 @@ jobs:
       matrix:
         sqlite_version: ["3.51.2"]
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: 'go.mod'
       - name: Download kubectl-schemahero binary
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: kubectl-schemahero
           path: bin/
@@ -386,12 +386,12 @@ jobs:
       matrix:
         rqlite_version: ["8.36.8", "9.3.18"]
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: 'go.mod'
       - name: Download kubectl-schemahero binary
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: kubectl-schemahero
           path: bin/
@@ -412,12 +412,12 @@ jobs:
       matrix:
         timescaledb_version: ["2.25.0-pg17"]
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: 'go.mod'
       - name: Download kubectl-schemahero binary
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: kubectl-schemahero
           path: bin/
@@ -445,21 +445,21 @@ jobs:
       digest: ${{ steps.release-manager.outputs.digest }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       - id: get_version
-        uses: battila7/get-version-action@v2
+        uses: battila7/get-version-action@d97fbc34ceb64d1f5d95f4dfd6dce33521ccccf5
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
         with:
           username: schemaherodeploy
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Docker meta for manager
         id: meta-manager
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9
         with:
           images: index.docker.io/schemahero/schemahero-manager
           tags: |
@@ -469,7 +469,7 @@ jobs:
             type=raw,value=latest,enable=${{ steps.get_version.outputs.prerelease == '' }}
       - name: Build and push
         id: release-manager
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
         with:
           context: .
           file: deploy/Dockerfile.multiarch
@@ -494,24 +494,24 @@ jobs:
       digest: ${{ steps.release-schemahero.outputs.digest }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - id: get_version
-        uses: battila7/get-version-action@v2
+        uses: battila7/get-version-action@d97fbc34ceb64d1f5d95f4dfd6dce33521ccccf5
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
         with:
           username: schemaherodeploy
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Docker meta for schemahero
         id: meta-schemahero
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9
         with:
           images: index.docker.io/schemahero/schemahero
           tags: |
@@ -521,7 +521,7 @@ jobs:
             type=raw,value=latest,enable=${{ steps.get_version.outputs.prerelease == '' }}
       - name: Build and push
         id: release-schemahero
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
         with:
           context: .
           file: deploy/Dockerfile.multiarch
@@ -546,24 +546,24 @@ jobs:
       digest: ${{ steps.release-slack-app.outputs.digest }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - id: get_version
-        uses: battila7/get-version-action@v2
+        uses: battila7/get-version-action@d97fbc34ceb64d1f5d95f4dfd6dce33521ccccf5
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
         with:
           username: schemaherodeploy
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Docker meta for slack app
         id: meta-slack-app
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9
         with:
           images: index.docker.io/schemahero/slack-app
           tags: |
@@ -573,7 +573,7 @@ jobs:
             type=raw,value=latest,enable=${{ steps.get_version.outputs.prerelease == '' }}
       - name: Build and push
         id: release-slack-app
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
         with:
           context: .
           file: deploy/Dockerfile.multiarch
@@ -595,16 +595,16 @@ jobs:
       - test-timescaledb
     if: always() && !cancelled()
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: 'go.mod'
           cache: true
           cache-dependency-path: ./go.sum
 
       - id: get_version
-        uses: battila7/get-version-action@v2
+        uses: battila7/get-version-action@d97fbc34ceb64d1f5d95f4dfd6dce33521ccccf5
 
       - id: get_prerelease_flag
         env:
@@ -623,7 +623,7 @@ jobs:
 
       - name: create github release
         id: create-github-release
-        uses: Hs1r1us/Release-AIO@v1.0
+        uses: Hs1r1us/Release-AIO@354b8db50d5b6310b621cb6c5e29d1f8e611aff7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -641,9 +641,9 @@ jobs:
       - build-docker-manager
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       - name: Create new schemahero version in krew-index
-        uses: rajatjindal/krew-release-bot@v0.0.51
+        uses: rajatjindal/krew-release-bot@c970b8a8f6dbc2f2285a26e3ae160903b87002c3
         with:
           krew_template_file: deploy/krew.yaml
 
@@ -654,9 +654,9 @@ jobs:
       - github-release-tarballs
     steps:
       - id: get_version
-        uses: battila7/get-version-action@v2
+        uses: battila7/get-version-action@d97fbc34ceb64d1f5d95f4dfd6dce33521ccccf5
       - name: Trigger homebrew-tap update
-        uses: peter-evans/repository-dispatch@v4
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697
         with:
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           repository: schemahero/homebrew-tap


### PR DESCRIPTION
> 🤖 An AI-generated pull request from [codeopsai](https://codeopsai.com). We open PRs only when we find a concrete, citable issue worth fixing. Not useful? Comment **"no thanks"** and we won't open more.

<details>
<summary>About codeopsai</summary>

codeopsai analyzes public GitHub Actions workflows for security and reliability issues and opens fixes for maintainer review. Every PR carries citations to the relevant standard (CWE, GitHub docs) and a structural verification trail; if our evidence bar isn't met, we don't open the PR.

**Mistake, or unwelcome?** Comment here or open an issue at [github.com/codeopsai/feedback](https://github.com/codeopsai/feedback). We read every one and adjust.
</details>

## Why these matter

**Why pin to a SHA** (`unpinned-action`)

Each unpinned action reference can be force-moved to attacker-controlled code by the action's owner or anyone who compromises their account — exactly what happened in the tj-actions/changed-files attack (CVE-2025-30066, Mar 2025). Pinning to a 40-character commit SHA freezes the exact reviewed code.

Reference: CWE-829 · [GitHub/OWASP guidance](https://docs.github.com/en/actions/reference/security/secure-use) · Real-world precedent: tj-actions/changed-files supply-chain attack (CVE-2025-30066, Mar 2025)

### `.github/workflows/build-and-test.yaml`

- 🟠 MED `dorny/paths-filter` (job `changes`)
- 🟠 MED `docker/setup-buildx-action` (job `build-docker-slack-app`)
- 🟠 MED `docker/build-push-action` (job `build-docker-slack-app`)
- ⚪ LOW `actions/checkout` (job `changes`)
- ⚪ LOW `actions/checkout` (job `build`)
- ⚪ LOW `actions/setup-go` (job `build`)
- ⚪ LOW `actions/upload-artifact` (job `build`)
- ⚪ LOW `actions/upload-artifact` (job `build`)
- ⚪ LOW `actions/upload-artifact` (job `build`)
- ⚪ LOW `actions/checkout` (job `test`)
- ⚪ LOW `actions/setup-go` (job `test`)
- ⚪ LOW `actions/checkout` (job `build-docker-slack-app`)
- ⚪ LOW `actions/checkout` (job `test-plugin-unit`)
- ⚪ LOW `actions/setup-go` (job `test-plugin-unit`)
- ⚪ LOW `actions/checkout` (job `test-postgres`)
- ⚪ LOW `actions/setup-go` (job `test-postgres`)
- ⚪ LOW `actions/download-artifact` (job `test-postgres`)
- ⚪ LOW `actions/checkout` (job `test-mysql`)
- ⚪ LOW `actions/setup-go` (job `test-mysql`)
- ⚪ LOW `actions/download-artifact` (job `test-mysql`)
- ⚪ LOW `actions/checkout` (job `test-cockroach`)
- ⚪ LOW `actions/setup-go` (job `test-cockroach`)
- ⚪ LOW `actions/download-artifact` (job `test-cockroach`)
- ⚪ LOW `actions/checkout` (job `test-cassandra`)
- ⚪ LOW `actions/setup-go` (job `test-cassandra`)
- ⚪ LOW `actions/download-artifact` (job `test-cassandra`)
- ⚪ LOW `actions/checkout` (job `test-sqlite`)
- ⚪ LOW `actions/setup-go` (job `test-sqlite`)
- ⚪ LOW `actions/download-artifact` (job `test-sqlite`)
- ⚪ LOW `actions/checkout` (job `test-rqlite`)
- ⚪ LOW `actions/setup-go` (job `test-rqlite`)
- ⚪ LOW `actions/download-artifact` (job `test-rqlite`)
- ⚪ LOW `actions/checkout` (job `test-timescaledb`)
- ⚪ LOW `actions/setup-go` (job `test-timescaledb`)
- ⚪ LOW `actions/download-artifact` (job `test-timescaledb`)
- ⚪ LOW `actions/checkout` (job `test-fixtures`)
- ⚪ LOW `actions/download-artifact` (job `test-fixtures`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -19,8 +19,8 @@
       rqlite: ${{ steps.filter.outputs.rqlite }}
       timescaledb: ${{ steps.filter.outputs.timescaledb }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         id: filter
         with:
           filters: |
@@ -58,24 +58,24 @@
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: 'go.mod'
           cache: true
           cache-dependency-path: ./go.sum
 
       - run: make manifests bin/kubectl-schemahero manager bin/schemahero-slack-app
-      - uses: actions/upload-artifact@v7.0.1
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: kubectl-schemahero
           path: bin/kubectl-schemahero
-      - uses: actions/upload-artifact@v7.0.1
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: manager
           path: bin/manager
-      - uses: actions/upload-artifact@v7.0.1
... (219 more diff lines — see Files changed)
```

</details>

### `.github/workflows/codeql-analysis.yml`

- ⚪ LOW `actions/checkout` (job `analyze`)
- ⚪ LOW `actions/setup-go` (job `analyze`)
- ⚪ LOW `github/codeql-action/init` (job `analyze`)
- ⚪ LOW `github/codeql-action/autobuild` (job `analyze`)
- ⚪ LOW `github/codeql-action/analyze` (job `analyze`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,9 +35,9 @@
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
-    - uses: actions/setup-go@v6
+    - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
       with:
         go-version-file: 'go.mod'
         cache: true
@@ -45,7 +45,7 @@
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -56,7 +56,7 @@
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v4
+      uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -70,4 +70,4 @@
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e
```

</details>

### `.github/workflows/factory-publish.yaml`

- 🟠 MED `elasticclaw/actions/publish-factory` (job `publish`)
- 🟠 MED `elasticclaw/actions/publish-template` (job `publish`)
- ⚪ LOW `actions/checkout` (job `publish`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/factory-publish.yaml
+++ b/.github/workflows/factory-publish.yaml
@@ -20,17 +20,17 @@
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Publish factory (schemahero-issues)
-        uses: elasticclaw/actions/publish-factory@main
+        uses: elasticclaw/actions/publish-factory@cac6be311a97b343108a3a1e4325e8063891c030
         with:
           hub-endpoint: https://factory.repldev.com
           token: ${{ secrets.ELASTICCLAW_TOKEN }}
           path: .elasticclaw/factories/schemahero-issues
 
       - name: Publish template (schemahero-developer)
-        uses: elasticclaw/actions/publish-template@main
+        uses: elasticclaw/actions/publish-template@cac6be311a97b343108a3a1e4325e8063891c030
         with:
           hub-endpoint: https://factory.repldev.com
           token: ${{ secrets.ELASTICCLAW_TOKEN }}
```

</details>

### `.github/workflows/factory-validate.yaml`

- 🟠 MED `elasticclaw/actions/publish-factory` (job `validate`)
- 🟠 MED `elasticclaw/actions/publish-template` (job `validate`)
- ⚪ LOW `actions/checkout` (job `validate`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/factory-validate.yaml
+++ b/.github/workflows/factory-validate.yaml
@@ -17,10 +17,10 @@
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Validate factory (schemahero-issues)
-        uses: elasticclaw/actions/publish-factory@main
+        uses: elasticclaw/actions/publish-factory@cac6be311a97b343108a3a1e4325e8063891c030
         with:
           hub-endpoint: https://factory.repldev.com
           token: ${{ secrets.ELASTICCLAW_TOKEN }}
@@ -28,7 +28,7 @@
           dry-run: true
 
       - name: Validate template (schemahero-developer)
-        uses: elasticclaw/actions/publish-template@main
+        uses: elasticclaw/actions/publish-template@cac6be311a97b343108a3a1e4325e8063891c030
         with:
           hub-endpoint: https://factory.repldev.com
           token: ${{ secrets.ELASTICCLAW_TOKEN }}
```

</details>

### `.github/workflows/nix.yml`

- 🟠 MED `cachix/install-nix-action` (job `nix-build`)
- 🟠 MED `cachix/install-nix-action` (job `nix-develop`)
- 🟠 MED `cachix/install-nix-action` (job `update-hashes`)
- 🟠 MED `peter-evans/create-pull-request` (job `update-hashes`)
- ⚪ LOW `actions/checkout` (job `nix-build`)
- ⚪ LOW `actions/checkout` (job `nix-develop`)
- ⚪ LOW `actions/checkout` (job `update-hashes`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -20,10 +20,10 @@
   nix-build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
     - name: Install Nix
-      uses: cachix/install-nix-action@v31
+      uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3
       with:
         nix_path: nixpkgs=channel:nixos-unstable
         extra_nix_config: |
@@ -46,10 +46,10 @@
   nix-develop:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
     - name: Install Nix
-      uses: cachix/install-nix-action@v31
+      uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3
       with:
         nix_path: nixpkgs=channel:nixos-unstable
         extra_nix_config: |
@@ -69,12 +69,12 @@
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Install Nix
-      uses: cachix/install-nix-action@v31
+      uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3
... (12 more diff lines — see Files changed)
```

</details>

### `.github/workflows/tagged-release.yaml`

- 🟠 MED `dorny/paths-filter` (job `changes`)
- 🟠 MED `battila7/get-version-action` (job `build-docker-manager`)
- 🟠 MED `docker/setup-qemu-action` (job `build-docker-manager`)
- 🟠 MED `docker/setup-buildx-action` (job `build-docker-manager`)
- 🟠 MED `docker/login-action` (job `build-docker-manager`)
- 🟠 MED `docker/metadata-action` (job `build-docker-manager`)
- 🟠 MED `docker/build-push-action` (job `build-docker-manager`)
- 🟠 MED `battila7/get-version-action` (job `build-docker-schemahero`)
- 🟠 MED `docker/setup-qemu-action` (job `build-docker-schemahero`)
- 🟠 MED `docker/setup-buildx-action` (job `build-docker-schemahero`)
- 🟠 MED `docker/login-action` (job `build-docker-schemahero`)
- 🟠 MED `docker/metadata-action` (job `build-docker-schemahero`)
- 🟠 MED `docker/build-push-action` (job `build-docker-schemahero`)
- 🟠 MED `battila7/get-version-action` (job `build-docker-slack-app`)
- 🟠 MED `docker/setup-qemu-action` (job `build-docker-slack-app`)
- 🟠 MED `docker/setup-buildx-action` (job `build-docker-slack-app`)
- 🟠 MED `docker/login-action` (job `build-docker-slack-app`)
- 🟠 MED `docker/metadata-action` (job `build-docker-slack-app`)
- 🟠 MED `docker/build-push-action` (job `build-docker-slack-app`)
- 🟠 MED `battila7/get-version-action` (job `github-release-tarballs`)
- 🟠 MED `Hs1r1us/Release-AIO` (job `github-release-tarballs`)
- 🟠 MED `rajatjindal/krew-release-bot` (job `krew`)
- 🟠 MED `battila7/get-version-action` (job `homebrew`)
- 🟠 MED `peter-evans/repository-dispatch` (job `homebrew`)
- ⚪ LOW `actions/checkout` (job `changes`)
- ⚪ LOW `actions/checkout` (job `build-postgres`)
- ⚪ LOW `actions/setup-go` (job `build-postgres`)
- ⚪ LOW `actions/checkout` (job `build-mysql`)
- ⚪ LOW `actions/setup-go` (job `build-mysql`)
- ⚪ LOW `actions/checkout` (job `build-timescaledb`)
- ⚪ LOW `actions/setup-go` (job `build-timescaledb`)
- ⚪ LOW `actions/checkout` (job `build-sqlite`)
- ⚪ LOW `actions/setup-go` (job `build-sqlite`)
- ⚪ LOW `actions/checkout` (job `build-rqlite`)
- ⚪ LOW `actions/setup-go` (job `build-rqlite`)
- ⚪ LOW `actions/checkout` (job `build-cassandra`)
- ⚪ LOW `actions/setup-go` (job `build-cassandra`)
- ⚪ LOW `actions/checkout` (job `build`)
- ⚪ LOW `actions/setup-go` (job `build`)
- ⚪ LOW `actions/upload-artifact` (job `build`)
- ⚪ LOW `actions/upload-artifact` (job `build`)
- ⚪ LOW `actions/checkout` (job `test-postgres`)
- ⚪ LOW `actions/setup-go` (job `test-postgres`)
- ⚪ LOW `actions/download-artifact` (job `test-postgres`)
- ⚪ LOW `actions/checkout` (job `test-mysql`)
- ⚪ LOW `actions/setup-go` (job `test-mysql`)
- ⚪ LOW `actions/download-artifact` (job `test-mysql`)
- ⚪ LOW `actions/checkout` (job `test-cockroach`)
- ⚪ LOW `actions/setup-go` (job `test-cockroach`)
- ⚪ LOW `actions/download-artifact` (job `test-cockroach`)
- ⚪ LOW `actions/checkout` (job `test-cassandra`)
- ⚪ LOW `actions/setup-go` (job `test-cassandra`)
- ⚪ LOW `actions/download-artifact` (job `test-cassandra`)
- ⚪ LOW `actions/checkout` (job `test-sqlite`)
- ⚪ LOW `actions/setup-go` (job `test-sqlite`)
- ⚪ LOW `actions/download-artifact` (job `test-sqlite`)
- ⚪ LOW `actions/checkout` (job `test-rqlite`)
- ⚪ LOW `actions/setup-go` (job `test-rqlite`)
- ⚪ LOW `actions/download-artifact` (job `test-rqlite`)
- ⚪ LOW `actions/checkout` (job `test-timescaledb`)
- ⚪ LOW `actions/setup-go` (job `test-timescaledb`)
- ⚪ LOW `actions/download-artifact` (job `test-timescaledb`)
- ⚪ LOW `actions/checkout` (job `build-docker-manager`)
- ⚪ LOW `actions/checkout` (job `build-docker-schemahero`)
- ⚪ LOW `actions/checkout` (job `build-docker-slack-app`)
- ⚪ LOW `actions/checkout` (job `github-release-tarballs`)
- ⚪ LOW `actions/setup-go` (job `github-release-tarballs`)
- ⚪ LOW `actions/checkout` (job `krew`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/tagged-release.yaml
+++ b/.github/workflows/tagged-release.yaml
@@ -19,8 +19,8 @@
       rqlite: ${{ steps.filter.outputs.rqlite }}
       cassandra: ${{ steps.filter.outputs.cassandra }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         id: filter
         with:
           filters: |
@@ -48,14 +48,14 @@
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Get plugin version
         id: version
         run: echo "VERSION=$(cat plugins/postgres/VERSION)" >> $GITHUB_OUTPUT
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: 'go.mod'
           cache: true
@@ -78,14 +78,14 @@
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Get plugin version
         id: version
         run: echo "VERSION=$(cat plugins/mysql/VERSION)" >> $GITHUB_OUTPUT
... (385 more diff lines — see Files changed)
```

</details>


---

_AI-generated. Review the diff before merging._
