### PR TITLE
Fix cache-docker-missing in tagged-release.yaml

### DIFF
--- a/.github/workflows/tagged-release.yaml
+++ b/.github/workflows/tagged-release.yaml
@@ -479,6 +479,8 @@ jobs:
           tags: ${{ steps.meta-manager.outputs.tags }}
           labels: ${{ steps.meta-manager.outputs.labels }}
 
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
   build-docker-schemahero:
     runs-on: ubuntu-latest
     needs:
@@ -529,6 +531,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta-schemahero.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           labels: ${{ steps.meta-schemahero.outputs.labels }}
 
   build-docker-slack-app:
@@ -579,6 +583,8 @@ jobs:
           file: deploy/Dockerfile.multiarch
           target: slack-app
           platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           push: true
           tags: ${{ steps.meta-slack-app.outputs.tags }}
           labels: ${{ steps.meta-slack-app.outputs.labels }}


### PR DESCRIPTION
> 🤖 An AI-generated pull request from [codeopsai](https://codeopsai.com). We open PRs only when we find a concrete, citable issue worth fixing. Not useful? Comment **"no thanks"** and we won't open more.

<details>
<summary>About codeopsai</summary>

codeopsai analyzes public GitHub Actions workflows for security and reliability issues and opens fixes for maintainer review. Every PR carries citations to the relevant standard (CWE, GitHub docs) and a structural verification trail; if our evidence bar isn't met, we don't open the PR.

**Mistake, or unwelcome?** Comment here or open an issue at [github.com/codeopsai/feedback](https://github.com/codeopsai/feedback). We read every one and adjust.
</details>

| Sev | Issue | Job | What changes |
| --- | ----- | --- | ------------ |
| 🟠 MED | `cache-docker-missing` | `build-docker-manager` | cache docker layers |
| 🟠 MED | `cache-docker-missing` | `build-docker-schemahero` | cache docker layers |
| 🟠 MED | `cache-docker-missing` | `build-docker-slack-app` | cache docker layers |

### 🟠 `cache-docker-missing` · `build-docker-manager`

The job 'build-docker-manager' uses the step 'Build and push' with docker/build-push-action@v7 and pushes the image, but the source YAML does not set cache-from or cache-to. Without layer caching, every tagged release rebuilds the Docker image from scratch.

Reference: [GitHub/OWASP guidance](https://docs.docker.com/build/cache/backends/gha/)

<details>
<summary>Evidence & diff</summary>

```diff
--- a/.github/workflows/tagged-release.yaml
+++ b/.github/workflows/tagged-release.yaml
@@ -479,6 +479,8 @@
           tags: ${{ steps.meta-manager.outputs.tags }}
           labels: ${{ steps.meta-manager.outputs.labels }}
 
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
   build-docker-schemahero:
     runs-on: ubuntu-latest
     needs:
@@ -529,6 +531,8 @@
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta-schemahero.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           labels: ${{ steps.meta-schemahero.outputs.labels }}
 
   build-docker-slack-app:
@@ -579,6 +583,8 @@
           file: deploy/Dockerfile.multiarch
           target: slack-app
           platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           push: true
           tags: ${{ steps.meta-slack-app.outputs.tags }}
           labels: ${{ steps.meta-slack-app.outputs.labels }}
```

</details>

### 🟠 `cache-docker-missing` · `build-docker-schemahero`

The job 'build-docker-schemahero' uses the step 'Build and push' with docker/build-push-action@v7 and pushes the image, but the source YAML does not set cache-from or cache-to. This makes repeated tag releases pay the full multi-arch build cost each time.

Reference: [GitHub/OWASP guidance](https://docs.docker.com/build/cache/backends/gha/)

### 🟠 `cache-docker-missing` · `build-docker-slack-app`

The job 'build-docker-slack-app' uses the step 'Build and push' with docker/build-push-action@v7 and pushes the image, but the source YAML does not set cache-from or cache-to. This causes repeated rebuilds of the slack-app image on every tagged release.

Reference: [GitHub/OWASP guidance](https://docs.docker.com/build/cache/backends/gha/)


---

_AI-generated. Review the diff before merging._
