### PR TITLE
Address 2 workflow findings in tagged-release.yaml

### DIFF
--- a/.github/workflows/tagged-release.yaml
+++ b/.github/workflows/tagged-release.yaml
@@ -479,6 +479,8 @@ jobs:
           tags: ${{ steps.meta-manager.outputs.tags }}
           labels: ${{ steps.meta-manager.outputs.labels }}
 
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
   build-docker-schemahero:
     runs-on: ubuntu-latest
     needs:
@@ -529,6 +531,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta-schemahero.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           labels: ${{ steps.meta-schemahero.outputs.labels }}
 
   build-docker-slack-app:
@@ -579,6 +583,8 @@ jobs:
           file: deploy/Dockerfile.multiarch
           target: slack-app
           platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           push: true
           tags: ${{ steps.meta-slack-app.outputs.tags }}
           labels: ${{ steps.meta-slack-app.outputs.labels }}
@@ -655,10 +661,19 @@ jobs:
     steps:
       - id: get_version
         uses: battila7/get-version-action@v2
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            homebrew-tap
+          permission-actions: write
       - name: Trigger homebrew-tap update
         uses: peter-evans/repository-dispatch@v4
         with:
-          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           repository: schemahero/homebrew-tap
           event-type: release
           client-payload: '{"version": "${{ steps.get_version.outputs.version-without-v }}"}'


### PR DESCRIPTION
> 🤖 An AI-generated pull request from [codeopsai](https://codeopsai.com). We open PRs only when we find a concrete, citable issue worth fixing. Not useful? Comment **"no thanks"** and we won't open more.

<details>
<summary>About codeopsai</summary>

codeopsai analyzes public GitHub Actions workflows for security and reliability issues and opens fixes for maintainer review. Every PR carries citations to the relevant standard (CWE, GitHub docs) and a structural verification trail; if our evidence bar isn't met, we don't open the PR.

**Mistake, or unwelcome?** Comment here or open an issue at [github.com/codeopsai/feedback](https://github.com/codeopsai/feedback). We read every one and adjust.
</details>

> ⚠️ **Advisory PR — maintainer setup required before merge.**
> 
> This PR inserts a GitHub App installation token step that references `vars.APP_ID` and `secrets.APP_PRIVATE_KEY` — neither exists yet on this repo. Complete the checklist below first, then mark the PR ready-for-review.

## Setup checklist

- [ ] **Register a GitHub App** with the permissions listed in the inserted step's `permission-<name>` inputs, and install it on the target repository.
- [ ] **Store the App's Client ID** in repository or organization variables as `APP_ID`.
- [ ] **Store the App's private key** in repository or organization secrets as `APP_PRIVATE_KEY`.

Once these three are done, mark this PR ready-for-review and merge. The `actions/create-github-app-token` step will generate a short-lived, repo-scoped token at runtime — strictly safer than the long-lived PAT it replaces.

| Sev | Issue | Job | What changes |
| --- | ----- | --- | ------------ |
| 🔴 HIGH | `pat-cross-repo` | `homebrew` | scope token to one repo |
| 🟠 MED | `cache-docker-missing` | `build-docker-manager` | cache docker layers |
| 🟠 MED | `cache-docker-missing` | `build-docker-schemahero` | cache docker layers |
| 🟠 MED | `cache-docker-missing` | `build-docker-slack-app` | cache docker layers |

### 🔴 `pat-cross-repo` · `homebrew`

In job `homebrew`, step `Trigger homebrew-tap update` uses the secret `HOMEBREW_TAP_TOKEN` as a PAT and the comprehension marks `cross_repo_confidence` as `high` with the cross-repo signal `repository_dispatch:schemahero/homebrew-tap`. This is a cross-repository credentialed wri…

Reference: CWE-1392 · [GitHub/OWASP guidance](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-06-Insufficient-Credential-Hygiene) · Real-world precedent: tj-actions/changed-files supply-chain attack (CVE-2025-30066, Mar 2025) — exfiltrated PATs

<details>
<summary>Evidence & diff</summary>

```diff
--- a/.github/workflows/tagged-release.yaml
+++ b/.github/workflows/tagged-release.yaml
@@ -479,6 +479,8 @@
           tags: ${{ steps.meta-manager.outputs.tags }}
           labels: ${{ steps.meta-manager.outputs.labels }}
 
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
   build-docker-schemahero:
     runs-on: ubuntu-latest
     needs:
@@ -529,6 +531,8 @@
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta-schemahero.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           labels: ${{ steps.meta-schemahero.outputs.labels }}
 
   build-docker-slack-app:
@@ -579,6 +583,8 @@
           file: deploy/Dockerfile.multiarch
           target: slack-app
           platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           push: true
           tags: ${{ steps.meta-slack-app.outputs.tags }}
           labels: ${{ steps.meta-slack-app.outputs.labels }}
@@ -655,10 +661,19 @@
     steps:
       - id: get_version
         uses: battila7/get-version-action@v2
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
... (10 more diff lines — see Files changed)
```

</details>

### 🟠 `cache-docker-missing` · `build-docker-manager`

In job `build-docker-manager`, step `Build and push` uses `docker/build-push-action@v7` and records a `docker_push` write operation, but the YAML shows no `cache-from` or `cache-to` inputs. This forces the multi-arch manager image to rebuild layers from scratch on every tagged r…

Reference: [GitHub/OWASP guidance](https://docs.docker.com/build/cache/backends/gha/)

### 🟠 `cache-docker-missing` · `build-docker-schemahero`

In job `build-docker-schemahero`, step `Build and push` uses `docker/build-push-action@v7` and records a `docker_push` write operation, but the YAML shows no `cache-from` or `cache-to` inputs. This makes the schemahero image build redo identical layers on each tagged release.

Reference: [GitHub/OWASP guidance](https://docs.docker.com/build/cache/backends/gha/)

### 🟠 `cache-docker-missing` · `build-docker-slack-app`

In job `build-docker-slack-app`, step `Build and push` uses `docker/build-push-action@v7` and records a `docker_push` write operation, but the YAML shows no `cache-from` or `cache-to` inputs. The slack-app image will therefore rebuild layers from scratch for every tagged release.

Reference: [GitHub/OWASP guidance](https://docs.docker.com/build/cache/backends/gha/)


---

_AI-generated. Review the diff before merging._
