### PR TITLE
Fix pat-cross-repo in tagged-release.yaml

### DIFF
--- a/.github/workflows/tagged-release.yaml
+++ b/.github/workflows/tagged-release.yaml
@@ -655,10 +655,19 @@ jobs:
     steps:
       - id: get_version
         uses: battila7/get-version-action@v2
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            homebrew-tap
+          permission-actions: write
       - name: Trigger homebrew-tap update
         uses: peter-evans/repository-dispatch@v4
         with:
-          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           repository: schemahero/homebrew-tap
           event-type: release
           client-payload: '{"version": "${{ steps.get_version.outputs.version-without-v }}"}'


### PR DESCRIPTION
> 🤖 An AI-generated pull request from [codeopsai](https://codeopsai.com). We open PRs only when we find a concrete, citable issue worth fixing. Not useful? Comment **"no thanks"** and we won't open more.

<details>
<summary>About codeopsai</summary>

codeopsai analyzes public GitHub Actions workflows for security and reliability issues and opens fixes for maintainer review. Every PR carries citations to the relevant standard (CWE, GitHub docs) and a structural verification trail; if our evidence bar isn't met, we don't open the PR.

**Mistake, or unwelcome?** Comment here or open an issue at [github.com/codeopsai/feedback](https://github.com/codeopsai/feedback). We read every one and adjust.
</details>

> ⚠️ **Advisory PR — maintainer setup required before merge.**
> 
> This PR inserts a GitHub App installation token step that references `vars.APP_ID` and `secrets.APP_PRIVATE_KEY` — neither exists yet on this repo. Complete the checklist below first, then mark the PR ready-for-review.

## Setup checklist

- [ ] **Register a GitHub App** with the permissions listed in the inserted step's `permission-<name>` inputs, and install it on the target repository.
- [ ] **Store the App's Client ID** in repository or organization variables as `APP_ID`.
- [ ] **Store the App's private key** in repository or organization secrets as `APP_PRIVATE_KEY`.

Once these three are done, mark this PR ready-for-review and merge. The `actions/create-github-app-token` step will generate a short-lived, repo-scoped token at runtime — strictly safer than the long-lived PAT it replaces.

### 🔴 `pat-cross-repo` · `homebrew`

Job `homebrew`, step `Trigger homebrew-tap update` uses `peter-evans/repository-dispatch@v4` with `secrets.HOMEBREW_TAP_TOKEN` as a PAT. The comprehension marks this token source with `cross_repo_confidence: high` and the cross-repo signal `repository_dispatch:schemahero/homebre…

Reference: CWE-1392 · [GitHub/OWASP guidance](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-06-Insufficient-Credential-Hygiene) · Real-world precedent: tj-actions/changed-files supply-chain attack (CVE-2025-30066, Mar 2025) — exfiltrated PATs

<details>
<summary>Evidence & diff</summary>

```diff
--- a/.github/workflows/tagged-release.yaml
+++ b/.github/workflows/tagged-release.yaml
@@ -655,10 +655,19 @@
     steps:
       - id: get_version
         uses: battila7/get-version-action@v2
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            homebrew-tap
+          permission-actions: write
       - name: Trigger homebrew-tap update
         uses: peter-evans/repository-dispatch@v4
         with:
-          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           repository: schemahero/homebrew-tap
           event-type: release
           client-payload: '{"version": "${{ steps.get_version.outputs.version-without-v }}"}'
```

</details>


---

_Have other repositories you'd like analysed? Request a scan at [codeopsai.com](https://codeopsai.com)._

---

_AI-generated. Review the diff before merging._
