### PR TITLE
fix(postgres): properly quote schema-qualified table and index names in DDL

### DIFF
--- a/plugins/postgres/lib/create.go
+++ b/plugins/postgres/lib/create.go
@@ -116,13 +116,21 @@ func CreateTableStatements(tableName string, tableSchema *schemasv1alpha4.Postgr
 		}
 	}
 
+	var tableIdentifier string
+	if tableSchema.Schema != "" && tableSchema.Schema != "public" {
+		tableIdentifier = pgx.Identifier{tableSchema.Schema, tableName}.Sanitize()
+	} else {
+		tableIdentifier = pgx.Identifier{tableName}.Sanitize()
+	}
+
+	// qualifiedTableName is the unquoted "schema.table" form used by trigger statements
 	qualifiedTableName := tableName
 	if tableSchema.Schema != "" && tableSchema.Schema != "public" {
 		qualifiedTableName = fmt.Sprintf("%s.%s", tableSchema.Schema, tableName)
 	}
 
 	queries := []string{
-		fmt.Sprintf(`create table %s (%s)`, pgx.Identifier{qualifiedTableName}.Sanitize(), strings.Join(columns, ", ")),
+		fmt.Sprintf(`create table %s (%s)`, tableIdentifier, strings.Join(columns, ", ")),
 	}
 
 	var triggers []*v1alpha4.PostgresqlTableTrigger

--- a/plugins/postgres/lib/create_test.go
+++ b/plugins/postgres/lib/create_test.go
@@ -151,6 +151,48 @@ func Test_CreateTableStatement(t *testing.T) {
 				`create trigger "tgr" after insert on "simple" for each row execute procedure test()`,
 			},
 		},
+		{
+			name: "non-public schema creates qualified table identifier",
+			tableSchema: &schemasv1alpha4.PostgresqlTableSchema{
+				Schema: "alerts_events",
+				Columns: []*schemasv1alpha4.PostgresqlTableColumn{
+					{
+						Name: "id",
+						Type: "character varying (64)",
+						Constraints: &schemasv1alpha4.PostgresqlTableColumnConstraints{
+							NotNull: &trueValue,
+						},
+					},
+					{
+						Name: "org_id",
+						Type: "character varying (64)",
+						Constraints: &schemasv1alpha4.PostgresqlTableColumnConstraints{
+							NotNull: &trueValue,
+						},
+					},
+				},
+			},
+			tableName: "alert_events",
+			expectedStatements: []string{
+				`create table "alerts_events"."alert_events" ("id" character varying (64) not null, "org_id" character varying (64) not null)`,
+			},
+		},
+		{
+			name: "public schema does not add schema qualifier",
+			tableSchema: &schemasv1alpha4.PostgresqlTableSchema{
+				Schema: "public",
+				Columns: []*schemasv1alpha4.PostgresqlTableColumn{
+					{
+						Name: "id",
+						Type: "integer",
+					},
+				},
+			},
+			tableName: "simple",
+			expectedStatements: []string{
+				`create table "simple" ("id" integer)`,
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/plugins/postgres/lib/deploy.go
+++ b/plugins/postgres/lib/deploy.go
@@ -453,7 +453,7 @@ DesiredIndexLoop:
 			indexStatements = append(indexStatements, statement)
 		}
 
-		statement = AddIndexStatement(tableName, index)
+		statement = AddIndexStatement(tableName, postgresTableSchema.Schema, index)
 		indexStatements = append(indexStatements, statement)
 	}
 

--- a/plugins/postgres/lib/index.go
+++ b/plugins/postgres/lib/index.go
@@ -21,7 +21,7 @@ func RemoveIndexStatement(tableName string, index *types.Index) string {
 	return fmt.Sprintf("drop index %s", pgx.Identifier{index.Name}.Sanitize())
 }
 
-func AddIndexStatement(tableName string, schemaIndex *schemasv1alpha4.PostgresqlTableIndex) string {
+func AddIndexStatement(tableName string, tableSchema string, schemaIndex *schemasv1alpha4.PostgresqlTableIndex) string {
 	unique := ""
 	if schemaIndex.IsUnique {
 		unique = "unique "
@@ -32,10 +32,17 @@ func AddIndexStatement(tableName string, schemaIndex *schemasv1alpha4.Postgresql
 		name = types.GeneratePostgresqlIndexName(tableName, schemaIndex)
 	}
 
+	var tableRef string
+	if tableSchema != "" && tableSchema != "public" {
+		tableRef = pgx.Identifier{tableSchema, tableName}.Sanitize()
+	} else {
+		tableRef = tableName
+	}
+
 	statement := fmt.Sprintf("create %sindex %s on %s (%s)",
 		unique,
 		name,
-		tableName,
+		tableRef,
 		strings.Join(schemaIndex.Columns, ", "))
 
 	if schemaIndex.With != nil && len(schemaIndex.With) > 0 {

--- a/plugins/postgres/lib/index_test.go
+++ b/plugins/postgres/lib/index_test.go
@@ -12,6 +12,7 @@ func Test_AddIndexStatement(t *testing.T) {
 	tests := []struct {
 		name              string
 		tableName         string
+		tableSchema       string
 		schemaIndex       *schemasv1alpha4.PostgresqlTableIndex
 		expectedStatement string
 	}{
@@ -101,11 +102,39 @@ func Test_AddIndexStatement(t *testing.T) {
 			},
 			expectedStatement: `create unique index idx_t2_c1 on t2 (c1) with (fillfactor = 90)`,
 		},
+		{
+			name:        "schema-qualified table, named index",
+			tableName:   "alert_events",
+			tableSchema: "alerts_events",
+			schemaIndex: &schemasv1alpha4.PostgresqlTableIndex{
+				Columns: []string{"org_id"},
+				Name:    "idx_alert_events_org_id",
+			},
+			expectedStatement: `create index idx_alert_events_org_id on "alerts_events"."alert_events" (org_id)`,
+		},
+		{
+			name:        "schema-qualified table, auto-generated index name",
+			tableName:   "t2",
+			tableSchema: "myschema",
+			schemaIndex: &schemasv1alpha4.PostgresqlTableIndex{
+				Columns: []string{"c1"},
+			},
+			expectedStatement: `create index idx_t2_c1 on "myschema"."t2" (c1)`,
+		},
+		{
+			name:        "public schema treated as no schema",
+			tableName:   "t2",
+			tableSchema: "public",
+			schemaIndex: &schemasv1alpha4.PostgresqlTableIndex{
+				Columns: []string{"c1"},
+			},
+			expectedStatement: `create index idx_t2_c1 on t2 (c1)`,
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			addIndexStatement := AddIndexStatement(test.tableName, test.schemaIndex)
+			addIndexStatement := AddIndexStatement(test.tableName, test.tableSchema, test.schemaIndex)
 
 			assert.Equal(t, test.expectedStatement, addIndexStatement)
 		})


### PR DESCRIPTION
## Summary

When a `Table` CRD specifies a non-public PostgreSQL schema (e.g. `schema: alerts_events`), the generated DDL was wrapping the schema and table name as a **single** quoted identifier:

```sql
create table "alerts_events.alert_events" (...)
```

instead of two **separate** quoted identifiers:

```sql
create table "alerts_events"."alert_events" (...)
```

This caused the table to be created under the `public` schema with a literal dot in its name, rather than in the intended schema.

The same bug affected `CREATE INDEX` statements, which referenced the unqualified table name and would fail if `search_path` did not include the target schema.

## Root cause

`pgx.Identifier{qualifiedTableName}.Sanitize()` was called with a pre-concatenated `"schema.table"` string, treating the whole thing as one identifier. The fix passes schema and table as separate elements: `pgx.Identifier{schema, tableName}.Sanitize()`.

## Changes

- `plugins/postgres/lib/create.go`: fix `CREATE TABLE` identifier quoting
- `plugins/postgres/lib/index.go`: fix `CREATE INDEX` table reference quoting (`AddIndexStatement` gains a `tableSchema` parameter)
- `plugins/postgres/lib/deploy.go`: pass schema to `AddIndexStatement`
- `plugins/postgres/lib/create_test.go`: add test cases for non-public and public schema
- `plugins/postgres/lib/index_test.go`: add test cases for schema-qualified index creation