### PR TITLE
fix: return error when vault service account has no secrets

### DIFF
--- a/pkg/apis/databases/v1alpha4/vault_connection.go
+++ b/pkg/apis/databases/v1alpha4/vault_connection.go
@@ -54,6 +54,10 @@ func (d *Database) getVaultConnection(ctx context.Context, clientset kubernetes.
 		return "", "", errors.Wrap(err, "failed to get vault service account")
 	}
 
+	if len(serviceAccount.Secrets) == 0 {
+		return "", "", errors.Errorf("vault service account %s has no secrets", valueOrValueFrom.ValueFrom.Vault.ServiceAccount)
+	}
+
 	vaultServiceAccountSecret := serviceAccount.Secrets[0]
 	vaultServiceAccountSecretNamespace := vaultServiceAccountSecret.Namespace
 	if vaultServiceAccountSecretNamespace == "" {

--- a/pkg/apis/databases/v1alpha4/vault_connection_no_secrets_test.go
+++ b/pkg/apis/databases/v1alpha4/vault_connection_no_secrets_test.go
@@ -1,0 +1,43 @@
+package v1alpha4
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestGetVaultConnectionServiceAccountWithoutSecrets(t *testing.T) {
+	// Kubernetes 1.24 and later no longer auto-create a token secret for a
+	// ServiceAccount, so ServiceAccount.Secrets can be empty. The native vault
+	// integration must return an error instead of indexing an empty slice.
+	sa := &v1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "schemahero",
+			Namespace: "default",
+		},
+	}
+
+	valueOrValueFrom := &ValueOrValueFrom{
+		ValueFrom: &ValueFrom{
+			Vault: &Vault{
+				Secret:         "secret",
+				ServiceAccount: "schemahero",
+				Endpoint:       "http://vault.example.com",
+			},
+		},
+	}
+
+	d := &Database{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+		},
+	}
+
+	_, _, err := d.getVaultConnection(context.TODO(), fake.NewClientset(sa), "postgres", valueOrValueFrom)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no secrets")
+}


### PR DESCRIPTION
getVaultConnection reads serviceAccount.Secrets[0] right after fetching the service account, but Kubernetes 1.24 and later no longer auto create a token secret, so that slice is empty on current clusters and the native vault integration panics with index out of range.

Check for an empty Secrets slice first and return a clear error naming the service account so operators know what to fix.