### PR TITLE
fix(postgres): correctly introspect composite foreign keys

### DIFF
--- a/integration/tests/postgres/Makefile
+++ b/integration/tests/postgres/Makefile
@@ -26,6 +26,7 @@ build-postgres-plugin:
 	make -C foreign-key-drop run
 	make -C foreign-key-alter run
 	make -C foreign-key-idempotent run
+	make -C foreign-key-idempotent-composite run
 	make -C not-null run
 	make -C not-null-with-default run
 	make -C index-create run
@@ -58,6 +59,7 @@ build-postgres-plugin:
 	make -C foreign-key-drop run
 	make -C foreign-key-alter run
 	make -C foreign-key-idempotent run
+	make -C foreign-key-idempotent-composite run
 	make -C not-null run
 	make -C not-null-with-default run
 	make -C index-create run
@@ -90,6 +92,7 @@ build-postgres-plugin:
 	make -C foreign-key-drop run
 	make -C foreign-key-alter run
 	make -C foreign-key-idempotent run
+	make -C foreign-key-idempotent-composite run
 	make -C not-null run
 	make -C not-null-with-default run
 	make -C index-create run
@@ -122,6 +125,7 @@ build-postgres-plugin:
 	make -C foreign-key-drop run
 	make -C foreign-key-alter run
 	make -C foreign-key-idempotent run
+	make -C foreign-key-idempotent-composite run
 	make -C not-null run
 	make -C not-null-with-default run
 	make -C index-create run
@@ -154,6 +158,7 @@ build-postgres-plugin:
 	make -C foreign-key-drop run
 	make -C foreign-key-alter run
 	make -C foreign-key-idempotent run
+	make -C foreign-key-idempotent-composite run
 	make -C not-null run
 	make -C not-null-with-default run
 	make -C index-create run

--- a/integration/tests/postgres/Makefile
+++ b/integration/tests/postgres/Makefile
@@ -27,6 +27,7 @@ build-postgres-plugin:
 	make -C foreign-key-alter run
 	make -C foreign-key-idempotent run
 	make -C foreign-key-idempotent-composite run
+	make -C foreign-key-idempotent-duplicate-name run
 	make -C not-null run
 	make -C not-null-with-default run
 	make -C index-create run
@@ -60,6 +61,7 @@ build-postgres-plugin:
 	make -C foreign-key-alter run
 	make -C foreign-key-idempotent run
 	make -C foreign-key-idempotent-composite run
+	make -C foreign-key-idempotent-duplicate-name run
 	make -C not-null run
 	make -C not-null-with-default run
 	make -C index-create run
@@ -93,6 +95,7 @@ build-postgres-plugin:
 	make -C foreign-key-alter run
 	make -C foreign-key-idempotent run
 	make -C foreign-key-idempotent-composite run
+	make -C foreign-key-idempotent-duplicate-name run
 	make -C not-null run
 	make -C not-null-with-default run
 	make -C index-create run
@@ -126,6 +129,7 @@ build-postgres-plugin:
 	make -C foreign-key-alter run
 	make -C foreign-key-idempotent run
 	make -C foreign-key-idempotent-composite run
+	make -C foreign-key-idempotent-duplicate-name run
 	make -C not-null run
 	make -C not-null-with-default run
 	make -C index-create run
@@ -159,6 +163,7 @@ build-postgres-plugin:
 	make -C foreign-key-alter run
 	make -C foreign-key-idempotent run
 	make -C foreign-key-idempotent-composite run
+	make -C foreign-key-idempotent-duplicate-name run
 	make -C not-null run
 	make -C not-null-with-default run
 	make -C index-create run

--- a/integration/tests/postgres/foreign-key-idempotent-composite/Dockerfile
+++ b/integration/tests/postgres/foreign-key-idempotent-composite/Dockerfile
@@ -1,0 +1,7 @@
+FROM postgres
+
+ENV POSTGRES_USER=schemahero
+ENV POSTGRES_DB=schemahero
+
+## Insert fixtures
+COPY ./fixtures.sql /docker-entrypoint-initdb.d/

--- a/integration/tests/postgres/foreign-key-idempotent-composite/Makefile
+++ b/integration/tests/postgres/foreign-key-idempotent-composite/Makefile
@@ -1,4 +1,4 @@
 include ../common.mk
 
 TEST_NAME := postgres-foreign-key-idempotent-composite
-SPEC_FILE := ./specs/category-pages.yaml
+SPEC_FILE := ./specs/t2.yaml

--- a/integration/tests/postgres/foreign-key-idempotent-composite/Makefile
+++ b/integration/tests/postgres/foreign-key-idempotent-composite/Makefile
@@ -1,0 +1,4 @@
+include ../common.mk
+
+TEST_NAME := postgres-foreign-key-idempotent-composite
+SPEC_FILE := ./specs/category-pages.yaml

--- a/integration/tests/postgres/foreign-key-idempotent-composite/fixtures.sql
+++ b/integration/tests/postgres/foreign-key-idempotent-composite/fixtures.sql
@@ -1,12 +1,12 @@
-create table categories (
-  category_id integer not null,
-  account_id integer not null,
-  primary key (category_id, account_id)
+create table t1 (
+  c1 integer not null,
+  c11 integer not null,
+  primary key (c1, c11)
 );
 
-create table category_pages (
+create table t2 (
   id integer primary key not null,
-  category_id integer not null,
-  account_id integer not null,
-  constraint category_pages_category_id_account_id_fkey foreign key (category_id, account_id) references categories (category_id, account_id) on delete cascade
+  c2 integer not null,
+  c22 integer not null,
+  constraint t2_c2_c22_fkey foreign key (c2, c22) references t1 (c1, c11) on delete cascade
 );

--- a/integration/tests/postgres/foreign-key-idempotent-composite/fixtures.sql
+++ b/integration/tests/postgres/foreign-key-idempotent-composite/fixtures.sql
@@ -1,0 +1,12 @@
+create table categories (
+  category_id integer not null,
+  account_id integer not null,
+  primary key (category_id, account_id)
+);
+
+create table category_pages (
+  id integer primary key not null,
+  category_id integer not null,
+  account_id integer not null,
+  constraint category_pages_category_id_account_id_fkey foreign key (category_id, account_id) references categories (category_id, account_id) on delete cascade
+);

--- a/integration/tests/postgres/foreign-key-idempotent-composite/specs/category-pages.yaml
+++ b/integration/tests/postgres/foreign-key-idempotent-composite/specs/category-pages.yaml
@@ -1,0 +1,28 @@
+database: schemahero
+name: category_pages
+schema:
+  postgres:
+    primaryKey: [id]
+    columns:
+      - name: id
+        type: integer
+        constraints:
+          notNull: true
+      - name: category_id
+        type: integer
+        constraints:
+          notNull: true
+      - name: account_id
+        type: integer
+        constraints:
+          notNull: true
+    foreignKeys:
+      - columns:
+          - category_id
+          - account_id
+        references:
+          table: categories
+          columns:
+            - category_id
+            - account_id
+        onDelete: cascade

--- a/integration/tests/postgres/foreign-key-idempotent-composite/specs/t2.yaml
+++ b/integration/tests/postgres/foreign-key-idempotent-composite/specs/t2.yaml
@@ -1,5 +1,5 @@
 database: schemahero
-name: category_pages
+name: t2
 schema:
   postgres:
     primaryKey: [id]
@@ -8,21 +8,21 @@ schema:
         type: integer
         constraints:
           notNull: true
-      - name: category_id
+      - name: c2
         type: integer
         constraints:
           notNull: true
-      - name: account_id
+      - name: c22
         type: integer
         constraints:
           notNull: true
     foreignKeys:
       - columns:
-          - category_id
-          - account_id
+          - c2
+          - c22
         references:
-          table: categories
+          table: t1
           columns:
-            - category_id
-            - account_id
+            - c1
+            - c11
         onDelete: cascade

--- a/integration/tests/postgres/foreign-key-idempotent-duplicate-name/Dockerfile
+++ b/integration/tests/postgres/foreign-key-idempotent-duplicate-name/Dockerfile
@@ -1,0 +1,7 @@
+FROM postgres
+
+ENV POSTGRES_USER=schemahero
+ENV POSTGRES_DB=schemahero
+
+## Insert fixtures
+COPY ./fixtures.sql /docker-entrypoint-initdb.d/

--- a/integration/tests/postgres/foreign-key-idempotent-duplicate-name/Makefile
+++ b/integration/tests/postgres/foreign-key-idempotent-duplicate-name/Makefile
@@ -1,0 +1,4 @@
+include ../common.mk
+
+TEST_NAME := postgres-foreign-key-idempotent-duplicate-name
+SPEC_FILE := ./specs/t2.yaml

--- a/integration/tests/postgres/foreign-key-idempotent-duplicate-name/fixtures.sql
+++ b/integration/tests/postgres/foreign-key-idempotent-duplicate-name/fixtures.sql
@@ -1,0 +1,24 @@
+-- Two schemas with identically named FK constraints.
+-- Joining information_schema.referential_constraints on constraint_name alone
+-- duplicates rows for public.t2 and falsely reports FK drift on re-plan.
+create schema other;
+
+create table other.t1 (
+  c1 integer primary key not null
+);
+
+create table other.t2 (
+  id integer primary key not null,
+  c2 integer not null,
+  constraint t2_c2_fkey foreign key (c2) references other.t1 (c1) on delete cascade
+);
+
+create table t1 (
+  c1 integer primary key not null
+);
+
+create table t2 (
+  id integer primary key not null,
+  c2 integer not null,
+  constraint t2_c2_fkey foreign key (c2) references t1 (c1) on delete cascade
+);

--- a/integration/tests/postgres/foreign-key-idempotent-duplicate-name/specs/t2.yaml
+++ b/integration/tests/postgres/foreign-key-idempotent-duplicate-name/specs/t2.yaml
@@ -1,0 +1,22 @@
+database: schemahero
+name: t2
+schema:
+  postgres:
+    primaryKey: [id]
+    columns:
+      - name: id
+        type: integer
+        constraints:
+          notNull: true
+      - name: c2
+        type: integer
+        constraints:
+          notNull: true
+    foreignKeys:
+      - columns:
+          - c2
+        references:
+          table: t1
+          columns:
+            - c1
+        onDelete: cascade

--- a/plugins/postgres/lib/tables.go
+++ b/plugins/postgres/lib/tables.go
@@ -147,11 +147,24 @@ func (p *PostgresConnection) ListTableForeignKeys(databaseName string, tableName
 	}
 
 	// Starting with a query here: https://stackoverflow.com/questions/1152260/postgres-sql-to-list-table-foreign-keys
+	//
+	// Read ON DELETE from pg_constraint.confdeltype instead of joining
+	// information_schema.referential_constraints on constraint_name alone.
+	// That join does not scope by schema, so identically named FKs in other
+	// schemas (e.g. public.t2_c2_fkey and other.t2_c2_fkey) duplicate rows and
+	// inflate ChildColumns/ParentColumns, causing perpetual drop/recreate drift.
 	query := `select
 	att2.attname as "child_column",
 	cl.relname as "parent_table",
 	att.attname as "parent_column",
-	rc.delete_rule,
+	case con.confdeltype
+		when 'a' then 'NO ACTION'
+		when 'r' then 'RESTRICT'
+		when 'c' then 'CASCADE'
+		when 'n' then 'SET NULL'
+		when 'd' then 'SET DEFAULT'
+		else ''
+	end as delete_rule,
 	con.conname,
 	ns2.nspname as "parent_schema"
     from
@@ -161,7 +174,8 @@ func (p *PostgresConnection) ListTableForeignKeys(databaseName string, tableName
 	    i as "ord",
 	    con1.confrelid,
 	    con1.conrelid,
-	    con1.conname
+	    con1.conname,
+	    con1.confdeltype
 	from
 	    pg_class cl
 	    join pg_namespace ns on cl.relnamespace = ns.oid
@@ -180,8 +194,6 @@ func (p *PostgresConnection) ListTableForeignKeys(databaseName string, tableName
        cl.relnamespace = ns2.oid
        join pg_attribute att2 on
 	   att2.attrelid = con.conrelid and att2.attnum = con.parent
-       join information_schema.referential_constraints rc on
-       rc.constraint_name = con.conname
     order by con.conname, con."ord"`
 
 	rows, err := p.conn.Query(context.Background(), query, actualTableName, schema)

--- a/plugins/postgres/lib/tables.go
+++ b/plugins/postgres/lib/tables.go
@@ -151,13 +151,14 @@ func (p *PostgresConnection) ListTableForeignKeys(databaseName string, tableName
 	att2.attname as "child_column",
 	cl.relname as "parent_table",
 	att.attname as "parent_column",
-  	rc.delete_rule,
-	conname,
+	rc.delete_rule,
+	con.conname,
 	ns2.nspname as "parent_schema"
     from
        (select
-	    unnest(con1.conkey) as "parent",
-	    unnest(con1.confkey) as "child",
+	    con1.conkey[i] as "parent",
+	    con1.confkey[i] as "child",
+	    i as "ord",
 	    con1.confrelid,
 	    con1.conrelid,
 	    con1.conname
@@ -165,6 +166,7 @@ func (p *PostgresConnection) ListTableForeignKeys(databaseName string, tableName
 	    pg_class cl
 	    join pg_namespace ns on cl.relnamespace = ns.oid
 	    join pg_constraint con1 on con1.conrelid = cl.oid
+	    cross join lateral generate_subscripts(con1.conkey, 1) as i
 	where
 	    cl.relname = $1
 	    and ns.nspname = $2
@@ -179,7 +181,8 @@ func (p *PostgresConnection) ListTableForeignKeys(databaseName string, tableName
        join pg_attribute att2 on
 	   att2.attrelid = con.conrelid and att2.attnum = con.parent
        join information_schema.referential_constraints rc on
-       rc.constraint_name = conname`
+       rc.constraint_name = con.conname
+    order by con.conname, con."ord"`
 
 	rows, err := p.conn.Query(context.Background(), query, actualTableName, schema)
 	if err != nil {
@@ -210,8 +213,8 @@ func (p *PostgresConnection) ListTableForeignKeys(databaseName string, tableName
 
 		for _, foundFk := range foreignKeys {
 			if foundFk.Name == name {
-				foundFk.ChildColumns = append(foreignKey.ChildColumns, childColumn)
-				foundFk.ParentColumns = append(foreignKey.ParentColumns, parentColumn)
+				foundFk.ChildColumns = append(foundFk.ChildColumns, childColumn)
+				foundFk.ParentColumns = append(foundFk.ParentColumns, parentColumn)
 
 				goto Appended
 			}


### PR DESCRIPTION
## What

Fixes #1405 — composite (multi-column) Postgres foreign keys dropped/recreated on every `plan`/`apply` even when the DB matches the spec.

Fixes #1412 — identically named FKs in other schemas inflate `ChildColumns`/`ParentColumns` via an unscoped `information_schema` join, causing the same perpetual drop/recreate (including single-column FKs).

## Why

`ListTableForeignKeys` in `plugins/postgres/lib/tables.go` introspected FKs incorrectly, so the introspected constraint never matched the spec and the diff perpetually emitted:

```sql
alter table child drop constraint "child_a_b_fkey";
alter table child add constraint child_a_b_fkey foreign key ("a", "b") references "parent" ("a", "b") on delete cascade;
```

### Composite FK drift (#1405)

Single-column FKs were unaffected. Two root causes:

1. **Aggregation appended to the wrong slice.** For the 2nd+ column of a constraint, the loop did `foundFk.ChildColumns = append(foreignKey.ChildColumns, childColumn)` — appending onto the freshly-built local `foreignKey` (a single-element slice for the *current* row) instead of the accumulator `foundFk`, yielding duplicated/incorrect columns.
2. **No deterministic column ordering.** The `unnest(conkey)/unnest(confkey)` query had no `ORDER BY`, so column order wasn't guaranteed to match the declaration order.

This is the foreign-key analogue of the primary-key ordering bug fixed for PKs in #1160 (which only touched the PK query).

### Duplicate constraint-name drift

Joining `information_schema.referential_constraints` on `constraint_name` alone does **not** scope by schema. When another schema has an identically named FK (common with Postgres' `{table}_{column}_fkey` auto-names), the join duplicates rows and SchemaHero sees columns like `[c2, c2]`, which never equals the spec.

## How

- Aggregate onto `foundFk` rather than the local `foreignKey`.
- Enumerate constraint columns via `generate_subscripts(con1.conkey, 1)` and `order by con.conname, con.ord`, so composite FK columns are returned in constraint-definition order.
- Read `ON DELETE` from `pg_constraint.confdeltype` instead of the unscoped `information_schema.referential_constraints` join.

## Testing

- `go test ./pkg/database/types/` and `gofmt` clean.
- Added `integration/tests/postgres/foreign-key-idempotent-composite` (two-column FK, `expect.sql` empty = no drift).
- Added `integration/tests/postgres/foreign-key-idempotent-duplicate-name` (same FK constraint name in `public` and `other` schemas; `expect.sql` empty = no drift).
- Both wired into every Postgres version block in `integration/tests/postgres/Makefile`.
- Verified end-to-end against production-like schemas: composite FK + colliding constraint names that previously produced perpetual drop/recreate now plan clean (empty) with the patched plugin.

