### PR TITLE
fix(postgres): preserve array column types when diffing

### DIFF
--- a/integration/tests/postgres/Makefile
+++ b/integration/tests/postgres/Makefile
@@ -18,6 +18,7 @@ build-postgres-plugin:
 	make -C column-set-default run
 	make -C column-unset-default run
 	make -C create-table run
+	make -C array-idempotent run
 	make -C create-table-with-index run
 	make -C schema-qualified-tables run
 	make -C drop-table run
@@ -50,6 +51,7 @@ build-postgres-plugin:
 	make -C column-unset-default run
 	make -C create-function run
 	make -C create-table run
+	make -C array-idempotent run
 	make -C create-table-with-index run
 	make -C schema-qualified-tables run
 	make -C drop-table run
@@ -82,6 +84,7 @@ build-postgres-plugin:
 	make -C column-unset-default run
 	make -C create-function run
 	make -C create-table run
+	make -C array-idempotent run
 	make -C create-table-with-index run
 	make -C schema-qualified-tables run
 	make -C drop-table run
@@ -114,6 +117,7 @@ build-postgres-plugin:
 	make -C column-unset-default run
 	make -C create-function run
 	make -C create-table run
+	make -C array-idempotent run
 	make -C create-table-with-index run
 	make -C schema-qualified-tables run
 	make -C drop-table run
@@ -146,6 +150,7 @@ build-postgres-plugin:
 	make -C column-unset-default run
 	make -C create-function run
 	make -C create-table run
+	make -C array-idempotent run
 	make -C create-table-with-index run
 	make -C schema-qualified-tables run
 	make -C drop-table run

--- a/integration/tests/postgres/array-idempotent/Dockerfile
+++ b/integration/tests/postgres/array-idempotent/Dockerfile
@@ -1,0 +1,7 @@
+FROM postgres
+
+ENV POSTGRES_USER=schemahero
+ENV POSTGRES_DB=schemahero
+
+## Insert fixtures
+COPY ./fixtures.sql /docker-entrypoint-initdb.d/

--- a/integration/tests/postgres/array-idempotent/Makefile
+++ b/integration/tests/postgres/array-idempotent/Makefile
@@ -1,0 +1,4 @@
+include ../common.mk
+
+TEST_NAME := postgres-array-idempotent
+SPEC_FILE := ./specs/t.yaml

--- a/integration/tests/postgres/array-idempotent/fixtures.sql
+++ b/integration/tests/postgres/array-idempotent/fixtures.sql
@@ -1,0 +1,7 @@
+create table t (
+  id integer primary key not null,
+  a varchar(255)[] not null,
+  b integer[] not null,
+  c text[] not null,
+  d boolean[] not null
+);

--- a/integration/tests/postgres/array-idempotent/specs/t.yaml
+++ b/integration/tests/postgres/array-idempotent/specs/t.yaml
@@ -1,0 +1,26 @@
+database: schemahero
+name: t
+schema:
+  postgres:
+    primaryKey: [id]
+    columns:
+      - name: id
+        type: integer
+        constraints:
+          notNull: true
+      - name: a
+        type: varchar(255)[]
+        constraints:
+          notNull: true
+      - name: b
+        type: integer[]
+        constraints:
+          notNull: true
+      - name: c
+        type: text[]
+        constraints:
+          notNull: true
+      - name: d
+        type: boolean[]
+        constraints:
+          notNull: true

--- a/plugins/postgres/lib/alter.go
+++ b/plugins/postgres/lib/alter.go
@@ -78,11 +78,13 @@ func AlterColumnStatements(tableName string, primaryKeys []string, desiredColumn
 			changes := []string{}
 			if column.DataType != "serial" && column.DataType != "bigserial" {
 				if existingColumn.DataType != column.DataType {
-					changes = append(changes, fmt.Sprintf("%s type %s", alterStatement, column.DataType))
-				} else if column.DataType == existingColumn.DataType {
-					if column.IsArray != existingColumn.IsArray {
-						changes = append(changes, fmt.Sprintf("%s type %s[] using %s::%s[]", alterStatement, column.DataType, pgx.Identifier{existingColumn.Name}.Sanitize(), column.DataType))
+					if column.IsArray {
+						changes = append(changes, fmt.Sprintf("%s type %s[]", alterStatement, column.DataType))
+					} else {
+						changes = append(changes, fmt.Sprintf("%s type %s", alterStatement, column.DataType))
 					}
+				} else if column.IsArray != existingColumn.IsArray {
+					changes = append(changes, fmt.Sprintf("%s type %s[] using %s::%s[]", alterStatement, column.DataType, pgx.Identifier{existingColumn.Name}.Sanitize(), column.DataType))
 				}
 
 				if column.ColumnDefault != nil {

--- a/plugins/postgres/lib/alter_test.go
+++ b/plugins/postgres/lib/alter_test.go
@@ -86,6 +86,38 @@ func Test_AlterColumnStatments(t *testing.T) {
 			expectedStatements: []string{},
 		},
 		{
+			name:      "no change varchar array",
+			tableName: "t",
+			desiredColumns: []*schemasv1alpha4.PostgresqlTableColumn{
+				{
+					Name: "a",
+					Type: "varchar(255)[]",
+				},
+			},
+			existingColumn: &types.Column{
+				Name:     "a",
+				DataType: "character varying (255)",
+				IsArray:  true,
+			},
+			expectedStatements: []string{},
+		},
+		{
+			name:      "change array element length",
+			tableName: "t",
+			desiredColumns: []*schemasv1alpha4.PostgresqlTableColumn{
+				{
+					Name: "a",
+					Type: "varchar(500)[]",
+				},
+			},
+			existingColumn: &types.Column{
+				Name:     "a",
+				DataType: "character varying (255)",
+				IsArray:  true,
+			},
+			expectedStatements: []string{`alter table "t" alter column "a" type character varying (500)[]`},
+		},
+		{
 			name:      "change data type",
 			tableName: "t",
 			desiredColumns: []*schemasv1alpha4.PostgresqlTableColumn{

--- a/plugins/postgres/lib/column.go
+++ b/plugins/postgres/lib/column.go
@@ -57,6 +57,27 @@ func schemaColumnToColumn(schemaColumn *schemasv1alpha4.PostgresqlTableColumn) (
 	return nil, fmt.Errorf("unknown column type. cannot validate column type %q", schemaColumn.Type)
 }
 
+// normalizePostgresColumnType resolves aliases and parameterized types the same
+// way schemaColumnToColumn does for desired columns, so an introspected type can
+// be compared against a desired type. It does not handle the array "[]" suffix and,
+// unlike schemaColumnToColumn, returns the input unchanged rather than erroring on
+// an unrecognized type.
+func normalizePostgresColumnType(requestedType string) string {
+	if unaliased := unaliasUnparameterizedColumnType(requestedType); unaliased != "" {
+		requestedType = unaliased
+	}
+	if unaliased := unaliasParameterizedColumnType(requestedType); unaliased != "" {
+		requestedType = unaliased
+	}
+	if !isParameterizedColumnType(requestedType) {
+		return requestedType
+	}
+	if columnType, err := maybeParseParameterizedColumnType(requestedType); err == nil && columnType != "" {
+		return columnType
+	}
+	return requestedType
+}
+
 func columnAsInsert(column *schemasv1alpha4.PostgresqlTableColumn) (string, error) {
 	// Note, we don't always quote the column type because of how pg handles these two statement very differently:
 

--- a/plugins/postgres/lib/deploy.go
+++ b/plugins/postgres/lib/deploy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/pkg/errors"
@@ -182,17 +183,17 @@ func PlanPostgresTableSeedDataOnly(uri string, tableName string, seedData *schem
 			Name: col.Name,
 			Type: col.DataType,
 		}
-		
+
 		if col.Constraints != nil && col.Constraints.NotNull != nil {
 			postgresCol.Constraints = &schemasv1alpha4.PostgresqlTableColumnConstraints{
 				NotNull: col.Constraints.NotNull,
 			}
 		}
-		
+
 		if col.ColumnDefault != nil {
 			postgresCol.Default = col.ColumnDefault
 		}
-		
+
 		postgresSchema.Columns = append(postgresSchema.Columns, postgresCol)
 	}
 
@@ -236,10 +237,14 @@ func executeStatements(p *PostgresConnection, statements []string) error {
 
 func BuildColumnStatements(p *PostgresConnection, tableName string, postgresTableSchema *schemasv1alpha4.PostgresqlTableSchema) ([]string, error) {
 	query := `select
-column_name, column_default, is_nullable, data_type, udt_name, character_maximum_length
-from information_schema.columns
-where table_name = $1 and table_schema = $2
-order by ordinal_position`
+c.column_name, c.column_default, c.is_nullable, c.data_type, c.udt_name, c.character_maximum_length,
+format_type(a.atttypid, a.atttypmod) as formatted_type
+from information_schema.columns c
+left join pg_catalog.pg_namespace n on n.nspname = c.table_schema
+left join pg_catalog.pg_class rel on rel.relname = c.table_name and rel.relnamespace = n.oid
+left join pg_catalog.pg_attribute a on a.attrelid = rel.oid and a.attname = c.column_name and a.attnum > 0 and not a.attisdropped
+where c.table_name = $1 and c.table_schema = $2
+order by c.ordinal_position`
 	rows, err := p.conn.Query(context.Background(), query, tableName, p.schema)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to select from information_schema")
@@ -252,8 +257,9 @@ order by ordinal_position`
 		var columnName, dataType, udtName, isNullable string
 		var columnDefault sql.NullString
 		var charMaxLength sql.NullInt64
+		var formattedType sql.NullString
 
-		if err := rows.Scan(&columnName, &columnDefault, &isNullable, &dataType, &udtName, &charMaxLength); err != nil {
+		if err := rows.Scan(&columnName, &columnDefault, &isNullable, &dataType, &udtName, &charMaxLength, &formattedType); err != nil {
 			return nil, errors.Wrap(err, "failed to scan")
 		}
 
@@ -268,7 +274,15 @@ order by ordinal_position`
 		switch dataType {
 		case "ARRAY":
 			existingColumn.IsArray = true
-			existingColumn.DataType = UDTNameToDataType(udtName)
+			// information_schema does not expose an array element's length, so use
+			// pg_catalog's format_type (e.g. "character varying(255)[]") and normalize
+			// the element type the same way desired column types are normalized.
+			if formattedType.Valid {
+				elementType := strings.TrimSuffix(formattedType.String, "[]")
+				existingColumn.DataType = normalizePostgresColumnType(elementType)
+			} else {
+				existingColumn.DataType = UDTNameToDataType(udtName)
+			}
 		case "USER-DEFINED":
 			existingColumn.DataType = UDTNameToDataType(udtName)
 		}


### PR DESCRIPTION
## What

Fixes #589 (refs #684) — a Postgres array column is altered to a **scalar** type on every `plan`/`apply`, even when the database already matches the spec.

## Why

For a column declared `varchar(255)[]`, `plan` perpetually emitted the destructive:

```sql
alter table "t" alter column "a" type character varying (255);
```

`BuildColumnStatements` introspected arrays via `information_schema`, which has two gaps:

1. **`UDTNameToDataType` only knew `_int4` and `_text`.** Every other element type (`_varchar`, `_bool`, …) was left as the raw `udt_name`, so the introspected `DataType` never matched the desired one. (Its own comment noted: *"This function only works for a few built-in types right now."*)
2. **The element length was unavailable.** For an array column, `information_schema.columns.character_maximum_length` is NULL, and `information_schema.element_types.character_maximum_length` is NULL as well — so `varchar(255)[]` lost its `(255)`.

Because the introspected type never matched, the diff always fired, and the emitted `alter` also dropped the `[]`, converting the array to scalar.

## How

- Introspect array columns from `pg_catalog`'s `format_type(atttypid, atttypmod)` (e.g. `character varying(255)[]`), strip the `[]`, and normalize the element type through the **same** alias/parameterized-type resolution used for desired columns (`normalizePostgresColumnType`). This handles all element types and their length/precision uniformly.
- In `AlterColumnStatements`, re-append `[]` when emitting a type change for an array column, so a legitimate array element-type change no longer converts the column to scalar.
- Scalar (non-array) introspection is unchanged.

## Testing

- `go build ./...`, `gofmt`, and `go test ./...` clean for the postgres plugin (added unit cases for array alters in `alter_test.go`).
- New `integration/tests/postgres/array-idempotent` (`varchar(255)[]`, `integer[]`, `text[]`, `boolean[]`, empty `expect.sql` = no drift), wired into every Postgres version block.
- Verified end-to-end against a real database: a `varchar(255)[]` column that previously produced a perpetual scalar `alter` now plans clean (empty).

## Not covered

Numeric/decimal array precision (e.g. `numeric(10,2)[]`) is not specifically handled; the existing scalar path shares the same limitation. Left as a follow-up to keep this change focused.
