### PR TITLE
fix(postgres): honor explicit unique index names on CREATE TABLE

### DIFF
--- a/pkg/database/types/index.go
+++ b/pkg/database/types/index.go
@@ -131,6 +131,12 @@ func GenerateMysqlIndexName(tableName string, schemaIndex *schemasv1alpha4.Mysql
 }
 
 func GeneratePostgresqlIndexName(tableName string, schemaIndex *schemasv1alpha4.PostgresqlTableIndex) string {
+	// Honor an explicit name from the Table spec so CREATE TABLE unique
+	// constraints match later ALTER/plan index names (avoids perpetual
+	// drop-constraint / create-unique-index rename drift).
+	if schemaIndex.Name != "" {
+		return schemaIndex.Name
+	}
 	return fmt.Sprintf("idx_%s_%s", tableName, strings.Join(schemaIndex.Columns, "_"))
 }
 

--- a/pkg/database/types/index_test.go
+++ b/pkg/database/types/index_test.go
@@ -6,6 +6,42 @@ import (
 	schemasv1alpha4 "github.com/schemahero/schemahero/pkg/apis/schemas/v1alpha4"
 )
 
+func Test_GeneratePostgresqlIndexName(t *testing.T) {
+	tests := []struct {
+		name        string
+		tableName   string
+		schemaIndex *schemasv1alpha4.PostgresqlTableIndex
+		want        string
+	}{
+		{
+			name:      "generated when name omitted",
+			tableName: "product_page_slugs",
+			schemaIndex: &schemasv1alpha4.PostgresqlTableIndex{
+				Columns:  []string{"slug"},
+				IsUnique: true,
+			},
+			want: "idx_product_page_slugs_slug",
+		},
+		{
+			name:      "explicit name preferred",
+			tableName: "product_page_slugs",
+			schemaIndex: &schemasv1alpha4.PostgresqlTableIndex{
+				Columns:  []string{"slug"},
+				Name:     "product_page_slugs_slug_idx",
+				IsUnique: true,
+			},
+			want: "product_page_slugs_slug_idx",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GeneratePostgresqlIndexName(tt.tableName, tt.schemaIndex); got != tt.want {
+				t.Errorf("GeneratePostgresqlIndexName() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
 func Test_GenerateMysqlIndexName(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/plugins/postgres/lib/create_test.go
+++ b/plugins/postgres/lib/create_test.go
@@ -94,6 +94,35 @@ func Test_CreateTableStatement(t *testing.T) {
 			},
 		},
 		{
+			name: "unique index with explicit name",
+			tableSchema: &schemasv1alpha4.PostgresqlTableSchema{
+				PrimaryKey: []string{
+					"id",
+				},
+				Indexes: []*schemasv1alpha4.PostgresqlTableIndex{
+					{
+						Columns:  []string{"slug"},
+						Name:     "product_page_slugs_slug_idx",
+						IsUnique: true,
+					},
+				},
+				Columns: []*schemasv1alpha4.PostgresqlTableColumn{
+					{
+						Name: "id",
+						Type: "integer",
+					},
+					{
+						Name: "slug",
+						Type: "varchar(400)",
+					},
+				},
+			},
+			tableName: "product_page_slugs",
+			expectedStatements: []string{
+				`create table "product_page_slugs" ("id" integer, "slug" character varying (400), primary key ("id"), constraint "product_page_slugs_slug_idx" unique ("slug"))`,
+			},
+		},
+		{
 			name: "simple with trigger",
 			tableSchema: &schemasv1alpha4.PostgresqlTableSchema{
 				PrimaryKey: []string{


### PR DESCRIPTION
## What

Fixes #1413 — `CREATE TABLE` ignored explicit unique index `name` from the Table spec and always used `idx_<table>_<cols>`, causing perpetual drop-constraint / create-unique-index rename drift on the next plan.

## How

`GeneratePostgresqlIndexName` now returns `schemaIndex.Name` when set (same preference as `AddIndexStatement`).

## Testing

- `go test ./pkg/database/types/ -run GeneratePostgresqlIndexName`
- `go test ./plugins/postgres/lib/ -run CreateTableStatement`

Made with [Cursor](https://cursor.com)