### PR TITLE
fix(postgres): leave SQL expression defaults unquoted

### DIFF
--- a/plugins/postgres/lib/alter.go
+++ b/plugins/postgres/lib/alter.go
@@ -47,20 +47,20 @@ func AlterColumnStatements(tableName string, primaryKeys []string, desiredColumn
 					// add default
 					if column.ColumnDefault != nil {
 						if existingColumn.ColumnDefault == nil || *existingColumn.ColumnDefault != *column.ColumnDefault {
-							localStatement := fmt.Sprintf("alter table %s alter column %s set default '%s'",
+							localStatement := fmt.Sprintf("alter table %s alter column %s set default %s",
 								pgx.Identifier{tableName}.Sanitize(),
 								pgx.Identifier{existingColumn.Name}.Sanitize(),
-								*column.ColumnDefault)
+								formatPostgresDefaultValue(*column.ColumnDefault))
 							statements = append(statements, localStatement)
 						}
 					}
 
 					// update existing values
 					if column.ColumnDefault != nil {
-						localStatement := fmt.Sprintf("update %s set %s='%s' where %s is null",
+						localStatement := fmt.Sprintf("update %s set %s=%s where %s is null",
 							pgx.Identifier{tableName}.Sanitize(),
 							pgx.Identifier{existingColumn.Name}.Sanitize(),
-							*column.ColumnDefault,
+							formatPostgresDefaultValue(*column.ColumnDefault),
 							pgx.Identifier{existingColumn.Name}.Sanitize())
 						statements = append(statements, localStatement)
 					}
@@ -87,7 +87,7 @@ func AlterColumnStatements(tableName string, primaryKeys []string, desiredColumn
 
 				if column.ColumnDefault != nil {
 					if existingColumn.ColumnDefault == nil || *column.ColumnDefault != *existingColumn.ColumnDefault {
-						changes = append(changes, fmt.Sprintf("%s set default '%s'", alterStatement, *column.ColumnDefault))
+						changes = append(changes, fmt.Sprintf("%s set default %s", alterStatement, formatPostgresDefaultValue(*column.ColumnDefault)))
 					}
 				} else if existingColumn.ColumnDefault != nil {
 					changes = append(changes, fmt.Sprintf("%s drop default", alterStatement))

--- a/plugins/postgres/lib/alter.go
+++ b/plugins/postgres/lib/alter.go
@@ -46,7 +46,7 @@ func AlterColumnStatements(tableName string, primaryKeys []string, desiredColumn
 
 					// add default
 					if column.ColumnDefault != nil {
-						if existingColumn.ColumnDefault == nil || *existingColumn.ColumnDefault != *column.ColumnDefault {
+						if !postgresDefaultsEqual(existingColumn.ColumnDefault, column.ColumnDefault) {
 							localStatement := fmt.Sprintf("alter table %s alter column %s set default %s",
 								pgx.Identifier{tableName}.Sanitize(),
 								pgx.Identifier{existingColumn.Name}.Sanitize(),
@@ -86,7 +86,7 @@ func AlterColumnStatements(tableName string, primaryKeys []string, desiredColumn
 				}
 
 				if column.ColumnDefault != nil {
-					if existingColumn.ColumnDefault == nil || *column.ColumnDefault != *existingColumn.ColumnDefault {
+					if !postgresDefaultsEqual(existingColumn.ColumnDefault, column.ColumnDefault) {
 						changes = append(changes, fmt.Sprintf("%s set default %s", alterStatement, formatPostgresDefaultValue(*column.ColumnDefault)))
 					}
 				} else if existingColumn.ColumnDefault != nil {
@@ -150,11 +150,7 @@ func columnsMatch(col1 types.Column, col2 types.Column) bool {
 		return false
 	}
 
-	if col1.ColumnDefault != nil && col2.ColumnDefault == nil {
-		return false
-	} else if col1.ColumnDefault == nil && col2.ColumnDefault != nil {
-		return false
-	} else if col1.ColumnDefault != nil && col2.ColumnDefault != nil && *col1.ColumnDefault != *col2.ColumnDefault {
+	if !postgresDefaultsEqual(col1.ColumnDefault, col2.ColumnDefault) {
 		return false
 	}
 

--- a/plugins/postgres/lib/alter_test.go
+++ b/plugins/postgres/lib/alter_test.go
@@ -43,6 +43,8 @@ func Test_AlterColumnStatments(t *testing.T) {
 	defaultEleven := "11"
 	defaultEmpty := ""
 	defaultNow := "now()"
+	defaultPending := "pending"
+	defaultQuotedPending := "'pending'"
 
 	tests := []struct {
 		name               string
@@ -280,6 +282,23 @@ func Test_AlterColumnStatments(t *testing.T) {
 				DataType: "timestamp without time zone",
 			},
 			expectedStatements: []string{`alter table "t" alter column "a" set default now()`},
+		},
+		{
+			name:      "quoted default matches stripped introspection",
+			tableName: "t",
+			desiredColumns: []*schemasv1alpha4.PostgresqlTableColumn{
+				{
+					Name:    "a",
+					Type:    "text",
+					Default: &defaultQuotedPending,
+				},
+			},
+			existingColumn: &types.Column{
+				Name:          "a",
+				DataType:      "text",
+				ColumnDefault: &defaultPending,
+			},
+			expectedStatements: []string{},
 		},
 		{
 			name:      "default unset",

--- a/plugins/postgres/lib/alter_test.go
+++ b/plugins/postgres/lib/alter_test.go
@@ -42,6 +42,7 @@ func Test_ColumnsMatch(t *testing.T) {
 func Test_AlterColumnStatments(t *testing.T) {
 	defaultEleven := "11"
 	defaultEmpty := ""
+	defaultNow := "now()"
 
 	tests := []struct {
 		name               string
@@ -265,6 +266,22 @@ func Test_AlterColumnStatments(t *testing.T) {
 			expectedStatements: []string{`alter table "t" alter column "a" set default '11'`},
 		},
 		{
+			name:      "default set now function",
+			tableName: "t",
+			desiredColumns: []*schemasv1alpha4.PostgresqlTableColumn{
+				{
+					Name:    "a",
+					Type:    "timestamp without time zone",
+					Default: &defaultNow,
+				},
+			},
+			existingColumn: &types.Column{
+				Name:     "a",
+				DataType: "timestamp without time zone",
+			},
+			expectedStatements: []string{`alter table "t" alter column "a" set default now()`},
+		},
+		{
 			name:      "default unset",
 			tableName: "t",
 			desiredColumns: []*schemasv1alpha4.PostgresqlTableColumn{
@@ -316,6 +333,29 @@ func Test_AlterColumnStatments(t *testing.T) {
 			expectedStatements: []string{
 				`alter table "t" alter column "a" set default '11'`,
 				`update "t" set "a"='11' where "a" is null`,
+				`alter table "t" alter column "a" set not null`,
+			},
+		},
+		{
+			name:      "add null and default now function",
+			tableName: "t",
+			desiredColumns: []*schemasv1alpha4.PostgresqlTableColumn{
+				{
+					Name:    "a",
+					Type:    "timestamp without time zone",
+					Default: &defaultNow,
+					Constraints: &schemasv1alpha4.PostgresqlTableColumnConstraints{
+						NotNull: &trueValue,
+					},
+				},
+			},
+			existingColumn: &types.Column{
+				Name:     "a",
+				DataType: "timestamp without time zone",
+			},
+			expectedStatements: []string{
+				`alter table "t" alter column "a" set default now()`,
+				`update "t" set "a"=now() where "a" is null`,
 				`alter table "t" alter column "a" set not null`,
 			},
 		},

--- a/plugins/postgres/lib/column.go
+++ b/plugins/postgres/lib/column.go
@@ -85,8 +85,7 @@ func columnAsInsert(column *schemasv1alpha4.PostgresqlTableColumn) (string, erro
 	}
 
 	if postgresColumn.ColumnDefault != nil {
-		value := stripOIDClass(*postgresColumn.ColumnDefault)
-		formatted = fmt.Sprintf("%s default '%s'", formatted, value)
+		formatted = fmt.Sprintf("%s default %s", formatted, formatPostgresDefaultValue(*postgresColumn.ColumnDefault))
 	}
 
 	return formatted, nil

--- a/plugins/postgres/lib/column_test.go
+++ b/plugins/postgres/lib/column_test.go
@@ -12,6 +12,9 @@ import (
 
 func Test_columnAsInsert(t *testing.T) {
 	default11 := "11"
+	defaultNow := "now()"
+	defaultPending := "'pending'"
+	defaultJSONB := "'{}'::jsonb"
 	tests := []struct {
 		name              string
 		column            *schemasv1alpha4.PostgresqlTableColumn
@@ -68,6 +71,33 @@ func Test_columnAsInsert(t *testing.T) {
 				Default: &default11,
 			},
 			expectedStatement: `"c" integer default '11'`,
+		},
+		{
+			name: "default now function",
+			column: &schemasv1alpha4.PostgresqlTableColumn{
+				Name:    "c",
+				Type:    "timestamp without time zone",
+				Default: &defaultNow,
+			},
+			expectedStatement: `"c" timestamp without time zone default now()`,
+		},
+		{
+			name: "default already quoted string",
+			column: &schemasv1alpha4.PostgresqlTableColumn{
+				Name:    "c",
+				Type:    "text",
+				Default: &defaultPending,
+			},
+			expectedStatement: `"c" text default 'pending'`,
+		},
+		{
+			name: "default jsonb cast",
+			column: &schemasv1alpha4.PostgresqlTableColumn{
+				Name:    "c",
+				Type:    "jsonb",
+				Default: &defaultJSONB,
+			},
+			expectedStatement: `"c" jsonb default '{}'::jsonb`,
 		},
 		{
 			name: "text[]",

--- a/plugins/postgres/lib/default.go
+++ b/plugins/postgres/lib/default.go
@@ -1,0 +1,51 @@
+package postgres
+
+import (
+	"fmt"
+	"strings"
+)
+
+// formatPostgresDefaultValue returns a SQL fragment suitable for DEFAULT
+// clauses and UPDATE assignments.
+//
+// Literal values are single-quoted. SQL expressions — function calls, casts,
+// already-quoted literals, and bare keywords — are emitted unchanged so
+// PostgreSQL keeps them as expressions (e.g. now() stays dynamic instead of
+// freezing to a timestamp literal). See https://github.com/schemahero/schemahero/issues/1345.
+func formatPostgresDefaultValue(value string) string {
+	if !shouldQuotePostgresDefault(value) {
+		return value
+	}
+
+	return fmt.Sprintf("'%s'", stripOIDClass(value))
+}
+
+func shouldQuotePostgresDefault(value string) bool {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return true
+	}
+
+	// Already a SQL string literal and/or cast (e.g. 'pending', '{}'::jsonb).
+	if strings.HasPrefix(trimmed, "'") {
+		return false
+	}
+
+	// Function call or parenthesized expression (e.g. now(), gen_random_uuid()).
+	if strings.Contains(trimmed, "(") {
+		return false
+	}
+
+	// Type cast without surrounding quotes (e.g. 0::integer).
+	if strings.Contains(trimmed, "::") {
+		return false
+	}
+
+	switch strings.ToUpper(trimmed) {
+	case "CURRENT_DATE", "CURRENT_TIME", "CURRENT_TIMESTAMP", "CURRENT_USER",
+		"FALSE", "LOCALTIME", "LOCALTIMESTAMP", "NULL", "SESSION_USER", "TRUE", "USER":
+		return false
+	}
+
+	return true
+}

--- a/plugins/postgres/lib/default.go
+++ b/plugins/postgres/lib/default.go
@@ -49,3 +49,28 @@ func shouldQuotePostgresDefault(value string) bool {
 
 	return true
 }
+
+// normalizePostgresDefault reduces a default to the form introspection stores
+// after stripOIDClass, so spec forms like "'pending'" and "'{}'::jsonb" compare
+// equal to introspected "pending" / "{}".
+func normalizePostgresDefault(value string) string {
+	value = strings.TrimSpace(value)
+	value = stripOIDClass(value)
+
+	if len(value) >= 2 && value[0] == '\'' && value[len(value)-1] == '\'' {
+		return strings.ReplaceAll(value[1:len(value)-1], "''", "'")
+	}
+
+	return value
+}
+
+func postgresDefaultsEqual(a *string, b *string) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+
+	return normalizePostgresDefault(*a) == normalizePostgresDefault(*b)
+}

--- a/plugins/postgres/lib/default_test.go
+++ b/plugins/postgres/lib/default_test.go
@@ -88,6 +88,11 @@ func Test_normalizePostgresDefault(t *testing.T) {
 			expected: "{}",
 		},
 		{
+			name:     "nextval keeps embedded cast",
+			value:    "nextval('seq'::regclass)",
+			expected: "nextval('seq'::regclass)",
+		},
+		{
 			name:     "function unchanged",
 			value:    "now()",
 			expected: "now()",
@@ -107,10 +112,14 @@ func Test_postgresDefaultsEqual(t *testing.T) {
 	jsonbCast := "'{}'::jsonb"
 	jsonb := "{}"
 	now := "now()"
+	nextval := "nextval('seq'::regclass)"
+	seq := "seq"
 
 	assert.True(t, postgresDefaultsEqual(&quotedPending, &pending))
 	assert.True(t, postgresDefaultsEqual(&jsonbCast, &jsonb))
 	assert.True(t, postgresDefaultsEqual(&now, &now))
+	assert.True(t, postgresDefaultsEqual(&nextval, &nextval))
+	assert.False(t, postgresDefaultsEqual(&nextval, &seq))
 	assert.False(t, postgresDefaultsEqual(&now, &pending))
 	assert.False(t, postgresDefaultsEqual(&now, nil))
 	assert.True(t, postgresDefaultsEqual(nil, nil))

--- a/plugins/postgres/lib/default_test.go
+++ b/plugins/postgres/lib/default_test.go
@@ -65,3 +65,53 @@ func Test_formatPostgresDefaultValue(t *testing.T) {
 		})
 	}
 }
+
+func Test_normalizePostgresDefault(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		expected string
+	}{
+		{
+			name:     "plain literal",
+			value:    "pending",
+			expected: "pending",
+		},
+		{
+			name:     "quoted literal",
+			value:    "'pending'",
+			expected: "pending",
+		},
+		{
+			name:     "oid cast",
+			value:    "'{}'::jsonb",
+			expected: "{}",
+		},
+		{
+			name:     "function unchanged",
+			value:    "now()",
+			expected: "now()",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, normalizePostgresDefault(test.value))
+		})
+	}
+}
+
+func Test_postgresDefaultsEqual(t *testing.T) {
+	quotedPending := "'pending'"
+	pending := "pending"
+	jsonbCast := "'{}'::jsonb"
+	jsonb := "{}"
+	now := "now()"
+
+	assert.True(t, postgresDefaultsEqual(&quotedPending, &pending))
+	assert.True(t, postgresDefaultsEqual(&jsonbCast, &jsonb))
+	assert.True(t, postgresDefaultsEqual(&now, &now))
+	assert.False(t, postgresDefaultsEqual(&now, &pending))
+	assert.False(t, postgresDefaultsEqual(&now, nil))
+	assert.True(t, postgresDefaultsEqual(nil, nil))
+}

--- a/plugins/postgres/lib/default_test.go
+++ b/plugins/postgres/lib/default_test.go
@@ -1,0 +1,67 @@
+package postgres
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_formatPostgresDefaultValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		expected string
+	}{
+		{
+			name:     "integer literal",
+			value:    "11",
+			expected: "'11'",
+		},
+		{
+			name:     "empty string literal",
+			value:    "",
+			expected: "''",
+		},
+		{
+			name:     "now function",
+			value:    "now()",
+			expected: "now()",
+		},
+		{
+			name:     "gen_random_uuid function",
+			value:    "gen_random_uuid()",
+			expected: "gen_random_uuid()",
+		},
+		{
+			name:     "current_timestamp keyword",
+			value:    "CURRENT_TIMESTAMP",
+			expected: "CURRENT_TIMESTAMP",
+		},
+		{
+			name:     "already quoted string",
+			value:    "'pending'",
+			expected: "'pending'",
+		},
+		{
+			name:     "jsonb cast literal",
+			value:    "'{}'::jsonb",
+			expected: "'{}'::jsonb",
+		},
+		{
+			name:     "true keyword",
+			value:    "true",
+			expected: "true",
+		},
+		{
+			name:     "plain text still quoted",
+			value:    "pending",
+			expected: "'pending'",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, formatPostgresDefaultValue(test.value))
+		})
+	}
+}

--- a/plugins/postgres/lib/oid.go
+++ b/plugins/postgres/lib/oid.go
@@ -2,7 +2,10 @@ package postgres
 
 import "regexp"
 
-var oidClassRegexp = regexp.MustCompile(`'(.*)'::.+`)
+// oidClassRegexp matches a full-string typed literal like `'pending'::text` or
+// `'{}'::jsonb`. It is anchored so embedded casts inside expressions
+// (e.g. nextval('seq'::regclass)) are left unchanged.
+var oidClassRegexp = regexp.MustCompile(`^'(.*)'::.+$`)
 
 func stripOIDClass(value string) string {
 	matches := oidClassRegexp.FindStringSubmatch(value)

--- a/plugins/postgres/lib/oid_test.go
+++ b/plugins/postgres/lib/oid_test.go
@@ -23,6 +23,16 @@ func Test_stripOIDClass(t *testing.T) {
 			value: `testing`,
 			want:  "testing",
 		},
+		{
+			name:  "embedded cast in nextval",
+			value: `nextval('seq'::regclass)`,
+			want:  `nextval('seq'::regclass)`,
+		},
+		{
+			name:  "jsonb cast",
+			value: `'{}'::jsonb`,
+			want:  "{}",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Stop always wrapping Postgres column defaults in single quotes on CREATE/ALTER/UPDATE paths.
- Emit SQL expressions unchanged (`now()`, `gen_random_uuid()`, `CURRENT_TIMESTAMP`, already-quoted literals, casts like `'{}'::jsonb`) while still quoting plain literals (`11`, `pending`).
- Fixes perpetual re-plans where `default: now()` became a frozen timestamp literal (`'2026-...'`) that never matched the desired schema.

Fixes #1345 (Postgres locations). MySQL/SQLite/Rqlite call sites from that issue are unchanged and can follow in a separate PR.

## Test plan
- [x] `go test ./lib/ -count=1` in `plugins/postgres`
- [ ] Confirm CREATE TABLE with `default: now()` emits `default now()` (not `default 'now()'`)
- [ ] Confirm ALTER SET DEFAULT / NOT NULL backfill paths emit unquoted `now()`
- [ ] Confirm literal defaults such as `11` and empty string remain quoted

Made with [Cursor](https://cursor.com)