### PR TITLE
Respect wokflow dependencies

### DIFF
--- a/.github/workflows/tagged-release.yaml
+++ b/.github/workflows/tagged-release.yaml
@@ -225,7 +225,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: [build-postgres, build-mysql, build-timescaledb, build-sqlite, build-rqlite, build-cassandra]
-    if: always() && !cancelled()
     steps:
       - uses: actions/checkout@v6
 
@@ -251,7 +250,6 @@ jobs:
   test-postgres:
     runs-on: ubuntu-latest
     needs: build
-    if: always() && !cancelled()
     strategy:
       matrix:
         postgres_version: ["14.20", "15.15", "16.11", "17.7", "18.1"]
@@ -277,7 +275,6 @@ jobs:
   test-mysql:
     runs-on: ubuntu-latest
     needs: build
-    if: always() && !cancelled()
     strategy:
       matrix:
         mysql_version: ["8.0.45", "8.4.8", "9.5.2"]
@@ -303,7 +300,6 @@ jobs:
   test-cockroach:
     runs-on: ubuntu-latest
     needs: build
-    if: always() && !cancelled()
     strategy:
       matrix:
         cockroachdb_version: ["v24.3.25", "v25.2.11", "v25.4.3"]
@@ -329,7 +325,6 @@ jobs:
   test-cassandra:
     runs-on: ubuntu-latest
     needs: build
-    if: always() && !cancelled()
     strategy:
       matrix:
         cassandra_version: ["4.0.19", "4.1.10", "5.0.6"]
@@ -355,7 +350,6 @@ jobs:
   test-sqlite:
     runs-on: ubuntu-latest
     needs: build
-    if: always() && !cancelled()
     strategy:
       matrix:
         sqlite_version: ["3.51.2"]
@@ -381,7 +375,6 @@ jobs:
   test-rqlite:
     runs-on: ubuntu-latest
     needs: build
-    if: always() && !cancelled()
     strategy:
       matrix:
         rqlite_version: ["8.36.8", "9.3.18"]
@@ -407,7 +400,6 @@ jobs:
   test-timescaledb:
     runs-on: ubuntu-latest
     needs: build
-    if: always() && !cancelled()
     strategy:
       matrix:
         timescaledb_version: ["2.25.0-pg17"]
@@ -440,7 +432,6 @@ jobs:
       - test-sqlite
       - test-rqlite
       - test-timescaledb
-    if: always() && !cancelled()
     outputs:
       digest: ${{ steps.release-manager.outputs.digest }}
     steps:
@@ -489,7 +480,6 @@ jobs:
       - test-sqlite
       - test-rqlite
       - test-timescaledb
-    if: always() && !cancelled()
     outputs:
       digest: ${{ steps.release-schemahero.outputs.digest }}
     steps:
@@ -541,7 +531,6 @@ jobs:
       - test-sqlite
       - test-rqlite
       - test-timescaledb
-    if: always() && !cancelled()
     steps:
       - uses: actions/checkout@v6
 
@@ -581,7 +570,7 @@ jobs:
           prerelease: ${{ steps.get_prerelease_flag.outputs.prerelease }}
 
   krew:
-    if: always() && !cancelled() && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'alpha') && !contains(github.ref, 'beta')
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'alpha') && !contains(github.ref, 'beta')
     runs-on: ubuntu-latest
     needs:
       - github-release-tarballs
@@ -596,7 +585,7 @@ jobs:
           krew_template_file: deploy/krew.yaml
 
   homebrew:
-    if: always() && !cancelled() && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'alpha') && !contains(github.ref, 'beta')
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'alpha') && !contains(github.ref, 'beta')
     runs-on: ubuntu-latest
     needs:
       - github-release-tarballs


### PR DESCRIPTION
1. `always() && !cancelled()` causes jobs to run even when prerequisites fail:
   - tests run even if build fails
   - release is created even if tests fail
2. `always() && !cancelled()` also causes passing jobs to run again when rerunning failed ones:
   - re-running a failed test, causes the release to be created again, resulting releaser and krew jobs to fail.


This caused release 0.26.1 to have failed CI: https://github.com/schemahero/schemahero/actions/runs/33810104005